### PR TITLE
Run tests in series as needed

### DIFF
--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -15,6 +15,7 @@ bitcoin = "0.20.0"
 rand = "0.6.5"
 env_logger = "0.7.1"
 floating-duration = "0.1.2"
+serial_test = "0.4.0"
 
 [dependencies.curv]
 git = "https://github.com/KZen-networks/curv"

--- a/integration-tests/src/batch_transfer_test.rs
+++ b/integration-tests/src/batch_transfer_test.rs
@@ -19,6 +19,7 @@ mod tests {
 
     /// Test batch transfer signature generation
     #[test]
+    #[serial]
     fn test_batch_sigs() {
         spawn_server();
         let mut wallet = gen_wallet();
@@ -102,6 +103,7 @@ mod tests {
 
     /// Perform batch transfer with tests and checks throughout
     #[test]
+    #[serial]
     fn test_batch_transfer() {
         spawn_server();
 
@@ -203,6 +205,7 @@ mod tests {
     /// Allow batch_lifetime time to pass, test punishments are set and test removal of punishment to completed transfer.
     /// *** THIS TEST REQUIRES batch_lifetime SERVER SETTING TO BE SET TO < 3 ***
     #[test]
+    #[serial]
     fn test_failure_batch_transfer() {
         spawn_server();
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -16,6 +16,9 @@ use std::{thread, time};
 use std::time::Instant;
 use floating_duration::TimeFormat;
 
+#[macro_use]
+extern crate serial_test;
+
 /// Spawn a fresh StateChain entity server
 pub fn spawn_server() {
     // Rocket server is blocking, so we spawn a new thread.

--- a/integration-tests/src/test.rs
+++ b/integration-tests/src/test.rs
@@ -13,6 +13,7 @@ mod tests {
 
 
     #[test]
+    #[serial]
     fn test_gen_shared_key() {
         spawn_server();
         let mut wallet = gen_wallet();
@@ -24,6 +25,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_failed_auth() {
         spawn_server();
         let client_shim = ClientShim::new("http://localhost:8000".to_string(), None);
@@ -52,7 +54,8 @@ mod tests {
     // }
 
     #[test]
-    fn test_deposit() {
+    #[serial]
+        fn test_deposit() {
         spawn_server();
         let wallet = gen_wallet_with_deposit(10000);
 
@@ -74,7 +77,8 @@ mod tests {
     }
 
     #[test]
-    fn test_get_statechain() {
+    #[serial]
+        fn test_get_statechain() {
         spawn_server();
         let mut wallet = gen_wallet();
 
@@ -88,6 +92,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_transfer() {
         spawn_server();
         let mut wallets = vec!();
@@ -129,6 +134,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_double_transfer() {
         spawn_server();
         let mut wallets = vec!();
@@ -196,6 +202,7 @@ mod tests {
 
 
     #[test]
+    #[serial]
     fn test_withdraw() {
         spawn_server();
         let mut wallet = gen_wallet_with_deposit(10000);
@@ -228,6 +235,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     /// Test wallet load from json correctly when shared key present.
     fn test_wallet_load_with_shared_key() {
         spawn_server();

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -40,6 +40,7 @@ monotree = "0.1.3"
 electrumx_client = { git = "https://github.com/commerceblock/rust-electrumx-client" }
 env_logger = "0.7.1"
 log4rs = "0.12.0"
+serial_test = "0.4.0"
 
 [dependencies.zk-paillier]
 git = "https://github.com/KZen-networks/zk-paillier"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -35,6 +35,9 @@ extern crate serde_dynamodb;
 
 extern crate hex;
 
+#[macro_use]
+extern crate serial_test;
+
 pub mod auth;
 pub mod routes;
 pub mod server;

--- a/server/src/storage/db.rs
+++ b/server/src/storage/db.rs
@@ -159,6 +159,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_db_root_update() {
         let db = rocksdb::DB::open_default(TEST_DB_LOC).unwrap();
         let root1: [u8;32] = [1;32];

--- a/server/src/tests.rs
+++ b/server/src/tests.rs
@@ -13,6 +13,7 @@ mod tests {
 
     // test ecdsa::sign can be performed only by authorised user
     #[test]
+    #[serial]
     fn test_auth_token() {
         let client = Client::new(server::get_server()).expect("valid rocket instance");
         // get ID
@@ -48,6 +49,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_err_get_statechain() {
         let client = Client::new(server::get_server()).expect("valid rocket instance");
 
@@ -69,6 +71,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_err_get_smt_proof() {
         let client = Client::new(server::get_server()).expect("valid rocket instance");
 
@@ -119,6 +122,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_err_get_transfer_batch_status() {
         let client = Client::new(server::get_server()).expect("valid rocket instance");
 
@@ -140,6 +144,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_state_entity_fees() {
         let client = Client::new(server::get_server()).expect("valid rocket instance");
 


### PR DESCRIPTION
The serial_test crate is used to serialise tests as needed.

Tests that need to be run in series are annotated with #[serial].

