### PR TITLE
Lockbox interface

### DIFF
--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -12,6 +12,7 @@ use postgres::Error as PostgresError;
 use rocket::http::{ContentType, Status};
 use rocket::response::Responder;
 use rocket::{Request, Response};
+use reqwest::Error as ReqwestError;
 use std::error;
 use std::fmt;
 use std::io::Cursor;
@@ -74,6 +75,12 @@ impl From<PostgresError> for SEError {
 }
 impl From<ConfigError> for SEError {
     fn from(e: ConfigError) -> SEError {
+        SEError::Generic(e.to_string())
+    }
+}
+
+impl From<ReqwestError> for SEError {
+    fn from(e: ReqwestError) -> SEError {
         SEError::Generic(e.to_string())
     }
 }

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -88,6 +88,16 @@ impl From<std::sync::PoisonError<std::sync::MutexGuard<'_, crate::protocol::cond
     }
 }
 
+impl From<Box<dyn std::error::Error>>
+    for SEError
+{
+    fn from(
+        e: Box<dyn std::error::Error>,
+    ) -> SEError {
+        SEError::Generic(e.to_string())
+    }
+}
+
 /// DB error types
 #[derive(Debug, Deserialize)]
 pub enum DBErrorType {

--- a/server/src/protocol/ecdsa.rs
+++ b/server/src/protocol/ecdsa.rs
@@ -3,11 +3,11 @@ pub use super::super::Result;
 use crate::error::{DBErrorType, SEError};
 use crate::Database;
 use crate::{server::StateChainEntity, structs::*};
-extern crate reqwest;
 use shared_lib::{
     structs::{KeyGenMsg1, KeyGenMsg2, Protocol, SignMsg1, SignMsg2},
     util::reverse_hex_str,
 };
+use super::requests::post_lb;
 
 use bitcoin::{hashes::sha256d, secp256k1::Signature, Transaction};
 use cfg_if::cfg_if;
@@ -67,80 +67,93 @@ impl Ecdsa for SCE {
     fn first_message(&self, key_gen_msg1: KeyGenMsg1) -> Result<(Uuid, party_one::KeyGenFirstMsg)> {
         let user_id = key_gen_msg1.shared_key_id;
         self.check_user_auth(&user_id)?;
-
         let db = &self.database;
 
-        // Create new entry in ecdsa table if key not already in table.
-        match db.get_ecdsa_master(user_id) {
-            Ok(data) => match data {
-                Some(_) => {
-                    return Err(SEError::Generic(format!(
-                        "Key Generation already completed for ID {}",
-                        user_id
-                    )))
-                }
-                None => {} // Key exists but key gen not complete. Carry on without writing user_id.
-            },
-            Err(e) => match e {
-                SEError::DBError(DBErrorType::NoDataForID, _) =>
-                // If no item has ID, create new item
-                {
-                    let _ = db.init_ecdsa(&user_id)?;
-                }
-                _ => return Err(e),
-            },
-        };
-
-        // Generate shared key
-        let (key_gen_first_msg, comm_witness, ec_key_pair) =
-            if key_gen_msg1.protocol == Protocol::Deposit {
-                MasterKey1::key_gen_first_message()
-            } else {
-                let s2: FE = db.get_ecdsa_s2(user_id)?;
-                let theta: FE = db.get_ecdsa_theta(user_id)?;
-                MasterKey1::key_gen_first_message_predefined(s2 * theta)
+        let kg_first_msg;
+        // call lockbox
+        if self.lockbox.active {
+            let path: &str = "/ecdsa/keygen/first";
+            let key_gen_first_msg: party_one::KeyGenFirstMsg = post_lb(&self.lockbox, path, &key_gen_msg1)?;
+            kg_first_msg = key_gen_first_msg;
+        }
+        else {
+            // Create new entry in ecdsa table if key not already in table.
+            match db.get_ecdsa_master(user_id) {
+                Ok(data) => match data {
+                    Some(_) => {
+                        return Err(SEError::Generic(format!(
+                            "Key Generation already completed for ID {}",
+                            user_id
+                        )))
+                    }
+                    None => {} // Key exists but key gen not complete. Carry on without writing user_id.
+                },
+                Err(e) => match e {
+                    SEError::DBError(DBErrorType::NoDataForID, _) =>
+                    // If no item has ID, create new item
+                    {
+                        let _ = db.init_ecdsa(&user_id)?;
+                    }
+                    _ => return Err(e),
+                },
             };
 
-        db.update_keygen_first_msg(&user_id, &key_gen_first_msg, comm_witness, ec_key_pair)?;
+            // Generate shared key
+            let (key_gen_first_msg, comm_witness, ec_key_pair) =
+                if key_gen_msg1.protocol == Protocol::Deposit {
+                    MasterKey1::key_gen_first_message()
+                } else {
+                    let s2: FE = db.get_ecdsa_s2(user_id)?;
+                    let theta: FE = db.get_ecdsa_theta(user_id)?;
+                    MasterKey1::key_gen_first_message_predefined(s2 * theta)
+                };
 
-        // call lockbox
-        if self.config.lockbox.is_empty() == false {
-            let path: &str = "/ecdsa/keygen/first";
-            let (_id, _kg_party_one_first_message): (Uuid, party_one::KeyGenFirstMsg) = self.lockbox.post(path,&key_gen_msg1)?;
+            db.update_keygen_first_msg(&user_id, &key_gen_first_msg, comm_witness, ec_key_pair)?;
+            kg_first_msg = key_gen_first_msg;
         }
 
-        Ok((user_id, key_gen_first_msg))
+        Ok((user_id, kg_first_msg))
     }
 
     fn second_message(&self, key_gen_msg2: KeyGenMsg2) -> Result<party1::KeyGenParty1Message2> {
-        let db = &self.database;
+        let kg_party_one_second_msg: party1::KeyGenParty1Message2;
+        // call lockbox
+        if self.lockbox.active {
+            let path: &str = "/ecdsa/keygen/second";
+            let kg_party_one_second_message: party1::KeyGenParty1Message2 = post_lb(&self.lockbox, path, &key_gen_msg2)?;
+            kg_party_one_second_msg = kg_party_one_second_message;
+        }
+        else {
+            let db = &self.database;
 
-        let user_id = key_gen_msg2.shared_key_id;
+            let user_id = key_gen_msg2.shared_key_id;
 
-        let party2_public: GE = key_gen_msg2.dlog_proof.pk.clone();
+            let party2_public: GE = key_gen_msg2.dlog_proof.pk.clone();
 
-        let (comm_witness, ec_key_pair) = db.get_ecdsa_witness_keypair(user_id)?;
+            let (comm_witness, ec_key_pair) = db.get_ecdsa_witness_keypair(user_id)?;
 
-        let (kg_party_one_second_message, paillier_key_pair, party_one_private): (
-            party1::KeyGenParty1Message2,
-            party_one::PaillierKeyPair,
-            party_one::Party1Private,
-        ) = MasterKey1::key_gen_second_message(
-            comm_witness,
-            &ec_key_pair,
-            &key_gen_msg2.dlog_proof,
-        );
+            let (kg_party_one_second_message, paillier_key_pair, party_one_private): (
+                party1::KeyGenParty1Message2,
+                party_one::PaillierKeyPair,
+                party_one::Party1Private,
+            ) = MasterKey1::key_gen_second_message(
+                comm_witness,
+                &ec_key_pair,
+                &key_gen_msg2.dlog_proof,
+            );
 
-        db.update_keygen_second_msg(
-            &user_id,
-            party2_public,
-            paillier_key_pair,
-            party_one_private,
-        )?;
+            db.update_keygen_second_msg(
+                &user_id,
+                party2_public,
+                paillier_key_pair,
+                party_one_private,
+            )?;
 
-        self.master_key(user_id)?;
+            self.master_key(user_id)?;
+            kg_party_one_second_msg = kg_party_one_second_message;
+        }
 
-        Ok(kg_party_one_second_message)
+        Ok(kg_party_one_second_msg)
     }
 
     fn sign_first(&self, sign_msg1: SignMsg1) -> Result<party_one::EphKeyGenFirstMsg> {
@@ -148,21 +161,31 @@ impl Ecdsa for SCE {
         let user_id = sign_msg1.shared_key_id;
         self.check_user_auth(&user_id)?;
 
-        let db = &self.database;
+        let sign_party_one_first_msg: party_one::EphKeyGenFirstMsg;
 
-        let (sign_party_one_first_message, eph_ec_key_pair_party1) :
-            //(multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::
-                (party_one::EphKeyGenFirstMsg, party_one::EphEcKeyPair) =
-            //(i64, i64) =
-            MasterKey1::sign_first_message();
+        if self.lockbox.active {
+            let path: &str = "/ecdsa/sign/first";
+            let sign_party_one_first_message: party_one::EphKeyGenFirstMsg = post_lb(&self.lockbox, path, &sign_msg1)?;
+            sign_party_one_first_msg = sign_party_one_first_message;
+        }
+        else {
+            let db = &self.database;
 
-        db.update_ecdsa_sign_first(
-            user_id,
-            sign_msg1.eph_key_gen_first_message_party_two,
-            eph_ec_key_pair_party1,
-        )?;
+            let (sign_party_one_first_message, eph_ec_key_pair_party1) :
+                //(multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::
+                    (party_one::EphKeyGenFirstMsg, party_one::EphEcKeyPair) =
+                //(i64, i64) =
+                MasterKey1::sign_first_message();
 
-        Ok(sign_party_one_first_message)
+            db.update_ecdsa_sign_first(
+                user_id,
+                sign_msg1.eph_key_gen_first_message_party_two,
+                eph_ec_key_pair_party1,
+            )?;
+            sign_party_one_first_msg = sign_party_one_first_message;
+        }
+
+        Ok(sign_party_one_first_msg)
     }
 
     fn sign_second(&self, sign_msg2: SignMsg2) -> Result<Vec<Vec<u8>>> {
@@ -194,23 +217,55 @@ impl Ecdsa for SCE {
             )));
         }
 
-        // Get 2P-Ecdsa data
-        let ssi: ECDSASignSecondInput = db.get_ecdsa_sign_second_input(user_id)?;
+        let mut ws: Vec<Vec<u8>>;
 
-        let signature;
-        match ssi.shared_key.sign_second_message(
-            &sign_msg2.sign_second_msg_request.party_two_sign_message,
-            &ssi.eph_key_gen_first_message_party_two,
-            &ssi.eph_ec_key_pair_party1,
-            &sign_msg2.sign_second_msg_request.message,
-        ) {
-            Ok(sig) => signature = sig,
-            Err(_) => {
-                return Err(SEError::SigningError(String::from(
-                    "Signature validation failed.",
-                )))
+        if self.lockbox.active {
+            let path: &str = "/ecdsa/sign/second";
+            let witness: Vec<Vec<u8>> = post_lb(&self.lockbox, path, &sign_msg2)?;
+            ws = witness;
+        }
+        else {
+            // Get 2P-Ecdsa data
+            let ssi: ECDSASignSecondInput = db.get_ecdsa_sign_second_input(user_id)?;
+
+            let signature;
+            match ssi.shared_key.sign_second_message(
+                &sign_msg2.sign_second_msg_request.party_two_sign_message,
+                &ssi.eph_key_gen_first_message_party_two,
+                &ssi.eph_ec_key_pair_party1,
+                &sign_msg2.sign_second_msg_request.message,
+            ) {
+                Ok(sig) => signature = sig,
+                Err(_) => {
+                    return Err(SEError::SigningError(String::from(
+                        "Signature validation failed.",
+                    )))
+                }
+            };
+
+            // Make signature witness
+            let mut r_vec = BigInt::to_vec(&signature.r);
+            if r_vec.len() != 32 {
+                // Check corrcet length of conversion to Signature
+                let mut temp = vec![0; 32 - r_vec.len()];
+                temp.extend(r_vec);
+                r_vec = temp;
             }
-        };
+            let mut s_vec = BigInt::to_vec(&signature.s);
+            if s_vec.len() != 32 {
+                // Check corrcet length of conversion to Signature
+                let mut temp = vec![0; 32 - s_vec.len()];
+                temp.extend(s_vec);
+                s_vec = temp;
+            }
+            let mut v = r_vec;
+            v.extend(s_vec);
+            let mut sig_vec = Signature::from_compact(&v[..])?.serialize_der().to_vec();
+            sig_vec.push(01);
+            let pk_vec = ssi.shared_key.public.q.get_element().serialize().to_vec();
+            let witness = vec![sig_vec, pk_vec];
+            ws = witness;
+        }
 
         // Get transaction which is being signed.
         let mut tx: Transaction = match sign_msg2.sign_second_msg_request.protocol {
@@ -218,30 +273,8 @@ impl Ecdsa for SCE {
             _ => db.get_user_backup_tx(user_id)?,
         };
 
-        // Make signature witness
-        let mut r_vec = BigInt::to_vec(&signature.r);
-        if r_vec.len() != 32 {
-            // Check corrcet length of conversion to Signature
-            let mut temp = vec![0; 32 - r_vec.len()];
-            temp.extend(r_vec);
-            r_vec = temp;
-        }
-        let mut s_vec = BigInt::to_vec(&signature.s);
-        if s_vec.len() != 32 {
-            // Check corrcet length of conversion to Signature
-            let mut temp = vec![0; 32 - s_vec.len()];
-            temp.extend(s_vec);
-            s_vec = temp;
-        }
-        let mut v = r_vec;
-        v.extend(s_vec);
-        let mut sig_vec = Signature::from_compact(&v[..])?.serialize_der().to_vec();
-        sig_vec.push(01);
-        let pk_vec = ssi.shared_key.public.q.get_element().serialize().to_vec();
-        let mut witness = vec![sig_vec, pk_vec];
-
         // Add signature to tx
-        tx.input[0].witness = witness.clone();
+        tx.input[0].witness = ws.clone();
 
         match sign_msg2.sign_second_msg_request.protocol {
             Protocol::Withdraw => {
@@ -250,7 +283,7 @@ impl Ecdsa for SCE {
 
                 info!("WITHDRAW: Tx signed and stored. User ID: {}", user_id);
                 // Do not return withdraw tx witness until /withdraw/confirm is complete
-                witness = vec![];
+                ws = vec![];
             }
             _ => {
                 // Store signed backup tx in UserSession DB object
@@ -262,7 +295,7 @@ impl Ecdsa for SCE {
             }
         };
 
-        Ok(witness)
+        Ok(ws)
     }
 }
 

--- a/server/src/protocol/ecdsa.rs
+++ b/server/src/protocol/ecdsa.rs
@@ -22,8 +22,6 @@ use rocket::State;
 use rocket_contrib::json::Json;
 use std::string::ToString;
 use uuid::Uuid;
-use std::time::Instant;
-use floating_duration::TimeFormat;
 
 cfg_if! {
     if #[cfg(any(test,feature="mockdb"))]{
@@ -111,21 +109,8 @@ impl Ecdsa for SCE {
 
         // call lockbox
         if self.config.lockbox.is_empty() == false {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            let start = Instant::now();
             let path: &str = "/ecdsa/keygen/first";
-            let url = format!("{}{}", self.config.lockbox, path);
-
-            let client = reqwest::blocking::Client::new();
-            let result = client.post(&url)
-                .json(&key_gen_msg1)
-                .send();
-
-            let _response = match result {
-                Ok(res) => info!("{} lockbox call status: {}", url.to_string(), res.status() ),
-                Err(err) => info!("ERROR: {} lockbox error: {}", url.to_string(), err),
-            };
-            info!("(req {}, took: {})", path, TimeFormat(start.elapsed()));
+            let (_id, _kg_party_one_first_message): (Uuid, party_one::KeyGenFirstMsg) = self.lockbox.post(path,&key_gen_msg1)?;
         }
 
         Ok((user_id, key_gen_first_msg))
@@ -157,48 +142,10 @@ impl Ecdsa for SCE {
             party_one_private,
         )?;
 
-        // call lockbox
-        if self.config.lockbox.is_empty() == false {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            let start = Instant::now();
-            let path: &str = "/ecdsa/keygen/second";
-            let url = format!("{}{}", self.config.lockbox, path);
-
-            let client = reqwest::blocking::Client::new();
-            let result = client.post(&url)
-                .json(&key_gen_msg2)
-                .send();
-
-            let _response = match result {
-                Ok(res) => info!("{} lockbox call status: {}", url.to_string(), res.status() ),
-                Err(err) => info!("ERROR: {} lockbox error: {}", url.to_string(), err),
-            };
-            info!("(req {}, took: {})", path, TimeFormat(start.elapsed()));
-        }
-
         Ok(kg_party_one_second_message)
     }
 
     fn third_message(&self, key_gen_msg3: KeyGenMsg3) -> Result<party_one::PDLFirstMessage> {
-
-        // call lockbox
-        if self.config.lockbox.is_empty() == false {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            let start = Instant::now();
-            let path: &str = "/ecdsa/keygen/third";
-            let url = format!("{}{}", self.config.lockbox, path);
-
-            let client = reqwest::blocking::Client::new();
-            let result = client.post(&url)
-                .json(&key_gen_msg3)
-                .send();
-
-            let _response = match result {
-                Ok(res) => info!("{} lockbox call status: {}", url.to_string(), res.status() ),
-                Err(err) => info!("ERROR: {} lockbox error: {}", url.to_string(), err),
-            };
-            info!("(req {}, took: {})", path, TimeFormat(start.elapsed()));
-        }
 
         let user_id = key_gen_msg3.shared_key_id;
         let db = &self.database;
@@ -238,48 +185,10 @@ impl Ecdsa for SCE {
 
         self.master_key(user_id)?;
 
-        // call lockbox
-        if self.config.lockbox.is_empty() == false {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            let start = Instant::now();
-            let path: &str = "/ecdsa/keygen/fourth";
-            let url = format!("{}{}", self.config.lockbox, path);
-
-            let client = reqwest::blocking::Client::new();
-            let result = client.post(&url)
-                .json(&key_gen_msg4)
-                .send();
-
-            let _response = match result {
-                Ok(res) => info!("{} lockbox call status: {}", url.to_string(), res.status() ),
-                Err(err) => info!("ERROR: {} lockbox error: {}", url.to_string(), err),
-            };
-            info!("(req {}, took: {})", path, TimeFormat(start.elapsed()));
-        }
-
         Ok(pdl_second_msg.unwrap())
     }
 
     fn sign_first(&self, sign_msg1: SignMsg1) -> Result<party_one::EphKeyGenFirstMsg> {
-        
-        // call lockbox
-        if self.config.lockbox.is_empty() == false {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            let start = Instant::now();
-            let path: &str = "/ecdsa/sign/first";
-            let url = format!("{}{}", self.config.lockbox, path);
-
-            let client = reqwest::blocking::Client::new();
-            let result = client.post(&url)
-                .json(&sign_msg1)
-                .send();
-
-            let _response = match result {
-                Ok(res) => info!("{} lockbox call status: {}", url.to_string(), res.status() ),
-                Err(err) => info!("ERROR: {} lockbox error: {}", url.to_string(), err),
-            };
-            info!("(req {}, took: {})", path, TimeFormat(start.elapsed()));
-        }
 
         let user_id = sign_msg1.shared_key_id;
         self.check_user_auth(&user_id)?;
@@ -302,25 +211,6 @@ impl Ecdsa for SCE {
     }
 
     fn sign_second(&self, sign_msg2: SignMsg2) -> Result<Vec<Vec<u8>>> {
-
-        // call lockbox
-        if self.config.lockbox.is_empty() == false {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            let start = Instant::now();
-            let path: &str = "/ecdsa/sign/second";
-            let url = format!("{}{}", self.config.lockbox, path);
-
-            let client = reqwest::blocking::Client::new();
-            let result = client.post(&url)
-                .json(&sign_msg2)
-                .send();
-
-            let _response = match result {
-                Ok(res) => info!("{} lockbox call status: {}", url.to_string(), res.status() ),
-                Err(err) => info!("ERROR: {} lockbox error: {}", url.to_string(), err),
-            };
-            info!("(req {}, took: {})", path, TimeFormat(start.elapsed()));
-        }
 
         let user_id = sign_msg2.shared_key_id;
         self.check_user_auth(&user_id)?;

--- a/server/src/protocol/mod.rs
+++ b/server/src/protocol/mod.rs
@@ -6,3 +6,4 @@ pub mod transfer;
 pub mod transfer_batch;
 pub mod util;
 pub mod withdraw;
+pub mod requests;

--- a/server/src/protocol/requests.rs
+++ b/server/src/protocol/requests.rs
@@ -1,0 +1,57 @@
+//! Requests
+//!
+//! Send requests and decode responses
+
+use floating_duration::TimeFormat;
+use serde;
+use std::time::Instant;
+
+use crate::server::Lockbox;
+use super::super::Result;
+use crate::error::SEError;
+
+pub fn post_lb<T, V>(lockbox: &Lockbox, path: &str, body: T) -> Result<V>
+where
+    T: serde::ser::Serialize,
+    V: serde::de::DeserializeOwned,
+{
+    _post_lb(lockbox, path, body)
+}
+
+fn _post_lb<T, V>(lockbox: &Lockbox, path: &str, body: T) -> Result<V>
+where
+    T: serde::ser::Serialize,
+    V: serde::de::DeserializeOwned,
+{
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    let start = Instant::now();
+
+    // catch reqwest errors
+    let value = match lockbox.client.post(&format!("{}/{}", lockbox.endpoint, path)).json(&body).send() 
+    {
+        Ok(v) => {
+            //Reject responses that are too long
+            match v.content_length() {
+                Some(l) => {
+                    if l > 1000000 {
+                        info!("Lockbox POST value ignored because of size: {}", l);
+                        return Err(SEError::Generic(format!(
+                            "Lockbox POST value ignored because of size: {}",
+                            l
+                        )));
+                    }
+                }
+                None => (),
+            };
+
+            let text = v.text()?;
+
+            text
+        }
+        Err(e) => return Err(SEError::from(e)),
+    };
+
+    info!("Lockbox request {}, took: {})", path, TimeFormat(start.elapsed()));
+    Ok(serde_json::from_str(value.as_str()).unwrap())
+}
+

--- a/server/src/protocol/transfer.rs
+++ b/server/src/protocol/transfer.rs
@@ -159,28 +159,18 @@ impl Transfer for SCE {
             )));
         }
 
-        // call lockbox
-        if self.config.lockbox.is_empty() == false {
-            let path: &str = "/transfer/receiver";
-            let url = format!("{}{}", self.config.lockbox, path);
-            let result = reqwest::blocking::get(&url);
-
-            let _response = match result {
-                Ok(res) => info!("transfer/receiver lockbox call status: {}", res.status() ),
-                Err(err) => eprintln!("transfer/receiver lockbox call status: {}", err),
-            };
-        }
-
         let s2: FE;
         let theta: FE;
         let s2_pub: GE;
         if self.lockbox.active {
             let ku_send = KUSendMsg {
+                user_id: user_id,
+                state_chain_id: state_chain_id,
                 x1: td.x1,
                 t1: transfer_msg4.t2,
                 o2_pub: transfer_msg4.o2_pub,
             };
-            let path: &str = "/ecdsa/keyupdate/first";
+            let path: &str = "ecdsa/keyupdate/first";
             let ku_receive: KUReceiveMsg = post_lb(&self.lockbox, path, &ku_send)?;
             s2 = FE::zero();
             s2_pub = ku_receive.s2_pub;
@@ -191,7 +181,6 @@ impl Transfer for SCE {
 
             // let x1 = transfer_data.x1;
             let t2 = transfer_msg4.t2;
-
             let s1 = kp.party_1_private.get_private_key();
 
             //let mut rng = OsRng::new().expect("OsRng");
@@ -301,6 +290,16 @@ impl Transfer for SCE {
             &state_chain_id,
             finalized_data.to_owned(),
         )?;
+
+        //lockbox finalise and delete key
+        if self.lockbox.active {
+            let ku_send = KUFinalize {
+                state_chain_id: state_chain_id,
+                shared_key_id: new_user_id,
+            };
+            let path: &str = "ecdsa/keyupdate/second";
+            let _ku_receive: KUAttest = post_lb(&self.lockbox, path, &ku_send)?;
+        }
 
         self.database
             .update_backup_tx(&state_chain_id, finalized_data.new_tx_backup.to_owned())?;
@@ -416,7 +415,8 @@ mod tests {
     };
     use chrono::{Duration, Utc};
     use mockall::predicate;
-    use std::str::FromStr;
+    use mockito;
+    use serde_json;
 
     // Data from a run of transfer protocol.
     // static TRANSFER_MSG_1: &str = "{\"shared_key_id\":\"707ea4c9-5ddb-4f08-a240-2b4d80ae630d\",\"state_chain_sig\":{\"purpose\":\"TRANSFER\",\"data\":\"0213be735d05adea658d78df4719072a6debf152845044402c5fe09dd41879fa01\",\"sig\":\"3044022028d56cfdb4e02d46b2f8158b0414746ddf42ecaaaa995a3a02df8807c5062c0202207569dc0f49b64ae997b4c902539cddc1f4e4434d6b4b05af38af4b98232ebee8\"}}";
@@ -653,5 +653,146 @@ mod tests {
         }
 
         sc_entity.transfer_receiver(transfer_msg_4)
+    }
+
+    #[test]
+    fn do_transfer_receiver_lockbox() {
+        let transfer_msg_4 =
+            serde_json::from_str::<TransferMsg4>(&TRANSFER_MSG_4.to_string()).unwrap();
+        let shared_key_id = transfer_msg_4.shared_key_id;
+        let state_chain_id = transfer_msg_4.state_chain_id;
+        let s2 = serde_json::from_str::<TransferFinalizeData>(&FINALIZED_DATA.to_string())
+            .unwrap()
+            .s2;
+        let theta = serde_json::from_str::<TransferFinalizeData>(&FINALIZED_DATA.to_string())
+            .unwrap()
+            .theta;
+        let msg2: TransferMsg2 = serde_json::from_str(&TRANSFER_MSG_2.to_string()).unwrap();
+        let x1 = msg2.x1.get_fe().expect("failed to get fe");
+
+        let mut db = MockDatabase::new();
+        db.expect_set_connection_from_config().returning(|_| Ok(()));
+        db.expect_get_user_auth()
+            .returning(move |_| Ok(shared_key_id));
+        db.expect_get_transfer_data()
+            .with(predicate::eq(state_chain_id))
+            .returning(move |_| {
+                Ok(TransferData {
+                    state_chain_id,
+                    state_chain_sig: serde_json::from_str::<TransferMsg4>(
+                        &TRANSFER_MSG_4.to_string(),
+                    )
+                    .unwrap()
+                    .state_chain_sig,
+                    x1,
+                })
+            });
+        db.expect_get_ecdsa_keypair()
+            .with(predicate::eq(shared_key_id))
+            .returning(|_| {
+                Ok(ECDSAKeypair {
+                    party_1_private: serde_json::from_str(&PARTY_1_PRIVATE.to_string()).unwrap(),
+                    party_2_public: serde_json::from_str(&PARTY_2_PUBLIC.to_string()).unwrap(),
+                })
+            });
+        db.expect_get_statechain().returning(move |_| {
+            Ok(serde_json::from_str::<StateChain>(&STATE_CHAIN.to_string()).unwrap())
+        });
+        db.expect_update_statechain_owner()
+            .returning(|_, _, _| Ok(()));
+        db.expect_transfer_init_user_session()
+            .returning(|_, _, _| Ok(()));
+        db.expect_update_backup_tx().returning(|_, _| Ok(()));
+        db.expect_remove_transfer_data().returning(|_| Ok(()));
+        db.expect_root_get_current_id().returning(|| Ok(1 as i64));
+        db.expect_get_root().returning(|_| Ok(None));
+        db.expect_root_update().returning(|_| Ok(1));
+        db.expect_get_finalize_batch_data().returning(move |_| {
+            Ok(TransferFinalizeBatchData {
+                finalized_data_vec: vec![TransferFinalizeData {
+                    new_shared_key_id: shared_key_id,
+                    state_chain_id,
+                    state_chain_sig: serde_json::from_str::<TransferMsg4>(
+                        &TRANSFER_MSG_4.to_string(),
+                    )
+                    .unwrap()
+                    .state_chain_sig,
+                    s2: s2,
+                    theta,
+                    new_tx_backup: serde_json::from_str::<Transaction>(
+                        &BACKUP_TX_NOT_SIGNED.to_string(),
+                    )
+                    .unwrap(),
+                    batch_data: Some(BatchData {
+                        id: shared_key_id,
+                        commitment: String::default(),
+                    }),
+                }],
+                start_time: Utc::now().naive_utc(),
+            })
+        });
+                
+        db.expect_update_finalize_batch_data()
+            .returning(|_, _| Ok(()));
+
+        let mut sc_entity = test_sc_entity(db);
+        let _m = mocks::ms::post_commitment().create(); //Mainstay post commitment mock
+
+        sc_entity.lockbox.active = true;
+        sc_entity.lockbox.endpoint = mockito::server_url();
+
+        // simulate lockbox secret operations
+        let kp = ECDSAKeypair {
+                    party_1_private: serde_json::from_str(&PARTY_1_PRIVATE.to_string()).unwrap(),
+                    party_2_public: serde_json::from_str(&PARTY_2_PUBLIC.to_string()).unwrap(),
+                };
+        let t2 = transfer_msg_4.t2;
+        let s1 = kp.party_1_private.get_private_key();
+
+        //let mut rng = OsRng::new().expect("OsRng");
+        let s2t = t2 * (x1.invert()) * s1;
+        let g: GE = ECPoint::generator();
+        let s2_pub = g * s2t;
+
+        let ku_lb_rec = KUReceiveMsg {
+            s2_pub: s2_pub,
+            theta: theta,
+        };
+
+        let serialized_m1 = serde_json::to_string(&ku_lb_rec).unwrap();
+
+        let _m_1 = mockito::mock("POST", "/ecdsa/keyupdate/first")
+          .with_header("content-type", "application/json")
+          .with_body(serialized_m1)
+          .create();
+
+        let ku_lb_fin_rec = KUAttest {
+            state_chain_id: state_chain_id,
+            attestation: "Attestation".to_string(),
+        };
+
+        let serialized_m2 = serde_json::to_string(&ku_lb_fin_rec).unwrap();
+
+        let _m_2 = mockito::mock("POST", "/ecdsa/keyupdate/second")
+          .with_header("content-type", "application/json")
+          .with_body(serialized_m2)
+          .create();        
+
+        // Input data to transfer_receiver
+        let transfer_msg_4 =
+            serde_json::from_str::<TransferMsg4>(&TRANSFER_MSG_4.to_string()).unwrap();
+
+        // StateChain incorreclty signed for
+        let mut msg_4_incorrect_sc = transfer_msg_4.clone();
+        msg_4_incorrect_sc.state_chain_sig.data =
+            "deadb33f88579c6aafcfcc8ca91b0556a2044e6c61dfb7fca5f90c40ed119349ec".to_string();
+        match sc_entity.transfer_receiver(msg_4_incorrect_sc) {
+            Ok(_) => assert!(false, "Expected failure."),
+            Err(e) => assert!(e
+                .to_string()
+                .contains("Error: State chain siganture provided does not match state chain at")),
+        }
+        // Expected successful run
+        assert!(sc_entity.transfer_receiver(transfer_msg_4.clone()).is_ok());
     }
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -25,7 +25,7 @@ use rocket_prometheus::{
     prometheus::{opts, IntCounter, IntCounterVec},
     PrometheusMetrics,
 };
-use reqwest::blocking::Client;
+use reqwest;
 use floating_duration::TimeFormat;
 use serde;
 use std::time::Instant;
@@ -55,11 +55,14 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[derive(Debug, Clone)]
 pub struct Lockbox {
-    pub client: Client,
+    pub client: reqwest::blocking::Client,
     pub endpoint: String,
 }
 
 impl Lockbox {
+    
+
+    
     pub fn connection(&self, endpoint: String) -> () {
         self.endpoint = endpoint.clone();
     }

--- a/shared/src/structs.rs
+++ b/shared/src/structs.rs
@@ -228,6 +228,8 @@ pub struct TransferMsg4 {
 /// State Entity -> Lockbox
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct KUSendMsg {
+    pub user_id: Uuid,
+    pub state_chain_id: Uuid,
     pub x1: FE,
     pub t1: FE,
     pub o2_pub: GE,
@@ -238,6 +240,18 @@ pub struct KUSendMsg {
 pub struct KUReceiveMsg {
     pub theta: FE,
     pub s2_pub: GE,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct KUFinalize {
+    pub state_chain_id: Uuid,
+    pub shared_key_id: Uuid,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct KUAttest {
+    pub state_chain_id: Uuid,
+    pub attestation: String,
 }
 
 /// State Entity -> Receiver

--- a/shared/src/structs.rs
+++ b/shared/src/structs.rs
@@ -225,6 +225,21 @@ pub struct TransferMsg4 {
     pub batch_data: Option<BatchData>,
 }
 
+/// State Entity -> Lockbox
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct KUSendMsg {
+    pub x1: FE,
+    pub t1: FE,
+    pub o2_pub: GE,
+}
+
+/// Lockbox -> State Entity
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct KUReceiveMsg {
+    pub theta: FE,
+    pub s2_pub: GE,
+}
+
 /// State Entity -> Receiver
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TransferMsg5 {


### PR DESCRIPTION
Interface:

ECDSA: 
first_message: KeyGenMsg1 -> party_one::KeyGenFirstMsg (user_id auth by server)
second_message: KeyGenMsg2 -> party1::KeyGenParty1Message2
sign_first: SignMsg1 -> party_one::EphKeyGenFirstMsg (user_id auth by server)
sign_second: SignMsg2 -> Vec<Vec<u8>> (lockbox return witness only: sighash checks, tx sig add and storage by server). 

Transfer:
x1 generated by server (transfer_sender). 
transfer_receiver: KUSendMsg -> KUReceiveMsg (lockbox receives [user_id, shared_key_id, x1, t1, o2_pub] and returns theta and s2_pub after creating a new s2 - but not deleting the old one yet in case of batch failure). 
transfer_finalize: KUFinalize -> KUAttest (lockbox receives [user_id, shared_key_id] and then deletes the old s2, and returns a deletion attestation). 
