### PR TITLE
confirmation checks

### DIFF
--- a/server/Settings.toml
+++ b/server/Settings.toml
@@ -1,7 +1,6 @@
 electrum_server = "127.0.0.1:60401"
 lockbox = ""
 network = "testnet"
-block_time = 2
 testing_mode = true
 # log_file = "log/output.log" # Comment out for stdout
 lockheight_init = 1000

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -84,14 +84,14 @@ pub struct Config {
     pub lockbox: String,
     /// Bitcoin network name (testnet, regtest, mainnet)
     pub network: String,
-    /// Block time of network
-    pub block_time: u64,
     /// Testing mode
     pub testing_mode: bool,
     /// Initial deposit backup nlocktime
     pub lockheight_init: u32,
     /// Transfer nlocktime decrement
     pub lh_decrement: u32,
+    /// Required confirmations for deposit
+    pub required_confirmation: u32,
     /// Receive address for fee payments
     pub fee_address: String,
     /// Despoit fee (basis points)
@@ -121,10 +121,10 @@ impl Default for Config {
             electrum_server: String::from("127.0.0.1:60401"),
             lockbox: String::from(""),
             network: String::from("regtest"),
-            block_time: 2,
             testing_mode: true,
             lockheight_init: 10000,
             lh_decrement: 100,
+            required_confirmation: 3,
             fee_address: String::from("bcrt1qjjwk2rk7nuxt6c79tsxthf5rpnky0sdhjr493x"),
             fee_deposit: 40,
             fee_withdraw: 40,

--- a/server/src/protocol/deposit.rs
+++ b/server/src/protocol/deposit.rs
@@ -98,7 +98,7 @@ impl Deposit for SCE {
             )));
         }
 
-        // Wait for funding tx existence in blockchain and confs
+        // Check that the funding transaction has the required number of confirmations
         self.verify_tx_confirmed(&tx_backup.input[0].previous_output.txid.to_string())?;
 
         // Create state chain DB object

--- a/server/src/protocol/util.rs
+++ b/server/src/protocol/util.rs
@@ -30,7 +30,6 @@ pub use monotree::Proof;
 use rocket::State;
 use rocket_contrib::json::Json;
 use std::str::FromStr;
-use std::{thread, time::Duration};
 use uuid::Uuid;
 use bitcoin::OutPoint;
 
@@ -428,7 +427,7 @@ pub fn reset_test_dbs(sc_entity: State<SCE>) -> Result<Json<()>> {
 // Utily functions for StateChainEntity to be used throughout codebase.
 impl SCE {
     /// Query an Electrum Server for a transaction's confirmation status.
-    /// Return Ok() if confirmed or Error if not after some waiting period.
+    /// Return Ok() if confirmed or Error if not within configured confirmation number.
     pub fn verify_tx_confirmed(&self, txid: &String) -> Result<()> {
         let mut electrum: Box<dyn Electrumx> = if self.config.testing_mode {
             Box::new(MockElectrum::new())
@@ -437,43 +436,33 @@ impl SCE {
         };
 
         info!(
-            "DEPOSIT: Waiting for funding transaction confirmation. Txid: {}",
+            "DEPOSIT: Verifying funding transaction confirmation. Txid: {}",
             txid
         );
 
-        let mut is_broadcast = 0; // num blocks waited for tx to be broadcast
-        let mut is_mined = 0; // num blocks waited for tx to be mined
-        while is_broadcast < 3 {
-            // Check for tx broadcast. If not after 3*(block time) then return error.
-            match electrum.get_transaction_conf_status(txid.clone(), false) {
-                Ok(res) => {
-                    // Check for tx confs. If none after 10*(block time) then return error.
-                    if res.confirmations.is_none() {
-                        is_mined += 1;
-                        if is_mined > 9 {
-                            warn!("Funding transaction not mined after 10 blocks. Deposit failed. Txid: {}", txid);
-                            return Err(SEError::Generic(String::from("Funding transaction failure to be mined - consider increasing the fee. Deposit failed.")));
-                        }
-                        thread::sleep(Duration::from_millis(self.config.block_time));
-                    } else {
-                        // If confs increase then wait 6*(block time) and return Ok()
-                        info!(
-                            "Funding transaction mined. Waiting for 6 blocks confirmation. Txid: {}",
-                            txid
-                        );
-                        thread::sleep(Duration::from_millis(6 * self.config.block_time));
-                        return Ok(());
-                    }
+        match electrum.get_transaction_conf_status(txid.clone(), false) {
+            Ok(res) => {
+                // Check for tx confs. If none after 10*(block time) then return error.
+                if res.confirmations.is_none() {
+                    return Err(SEError::Generic(String::from(
+                        "Funding Transaction not confirmed.",
+                    )));
+                } 
+                else if res.confirmations.unwrap() < self.config.required_confirmation {
+                    return Err(SEError::Generic(String::from(
+                        "Funding Transaction insufficient confirmations.",
+                    )));                    
                 }
-                Err(_) => {
-                    is_broadcast += 1;
-                    thread::sleep(Duration::from_millis(self.config.block_time));
+                else {
+                    return Ok(());
                 }
             }
+            Err(_) => {
+                return Err(SEError::Generic(String::from(
+                    "Funding Transaction not found.",
+                )));
+            }
         }
-        return Err(SEError::Generic(String::from(
-            "Funding Transaction not found in blockchain. Deposit failed.",
-        )));
     }
 
     // Set state chain time-out

--- a/shared/src/mocks/mock_electrum.rs
+++ b/shared/src/mocks/mock_electrum.rs
@@ -77,7 +77,7 @@ impl Electrumx for MockElectrum {
     ) -> Result<GetTransactionConfStatus, Box<dyn std::error::Error>> {
         Ok(GetTransactionConfStatus {
             in_active_chain: Some(true),
-            confirmations: Some(2),
+            confirmations: Some(3),
             blocktime: Some(123456789),
         })
     }


### PR DESCRIPTION
`verify_tx_confirmed` now just checks that the deposit tx is confirmed within `required_confirmation` which is set in the config. If not, it returns error with details : "Funding Transaction not found.", "Funding Transaction not confirmed.", "Funding Transaction insufficient confirmations."

`verify_tx_confirmed` also called when starting a `transfer_sender`

`block_time` removed from the config. 