### PR TITLE
Enable transfer rollback

### DIFF
--- a/server/Settings.toml
+++ b/server/Settings.toml
@@ -3,7 +3,6 @@ lockbox = ""
 network = "testnet"
 required_confirmation = 0
 testing_mode = true
-log_file = "log/output.log" # Comment out for stdout
 lockheight_init = 10000
 lh_decrement = 100
 
@@ -15,7 +14,7 @@ fee_withdraw = 300
 # Swap parameters
 punishment_duration = "3600" # 1 hour
 utxo_timeout = "60"
-batch_lifetime = "3600" # 1 hour
+batch_lifetime = "600" # 1 hour
 
 #Mainstay config
 mainstay_config = ""

--- a/server/Settings.toml
+++ b/server/Settings.toml
@@ -3,6 +3,7 @@ lockbox = ""
 network = "testnet"
 required_confirmation = 0
 testing_mode = true
+log_file = "log/output.log" # Comment out for stdout
 lockheight_init = 10000
 lh_decrement = 100
 

--- a/server/src/protocol/transfer.rs
+++ b/server/src/protocol/transfer.rs
@@ -100,13 +100,6 @@ impl Transfer for SCE {
         // Check that the funding transaction has the required number of confirmations
         self.verify_tx_confirmed(&tx_backup.input[0].previous_output.txid.to_string())?;
 
-        // Check if transfer has already been completed (but not finalized)
-        if self.database.transfer_is_completed(statechain_id) {
-            return Err(SEError::Generic(String::from(
-                "Transfer already completed. Waiting for finalize.",
-            )));
-        }
-
         // Check if state chain is owned by user and not locked
         let sco = self.database.get_statechain_owner(statechain_id)?;
 

--- a/server/src/protocol/util.rs
+++ b/server/src/protocol/util.rs
@@ -372,13 +372,16 @@ impl Utilities for SCE {
                 if prepare_sign_msg.protocol == Protocol::Transfer {
                     //verify transfer locktime is correct
                     let statechain_id = self.database.get_statechain_id(user_id)?;
-                    let current_tx_backup = self.database.get_backup_transaction(statechain_id)?;
+                    let current_tx_backup = self.database.get_backup_transaction(statechain_id.clone())?;
 
                     if (current_tx_backup.lock_time as u32) != (tx.lock_time as u32) + (self.config.lh_decrement as u32) {
                         return Err(SEError::Generic(String::from(
                             "Backup tx locktime not correctly decremented.",
                         )));
                     }
+                    // add unsigned transaction to backup store
+                    // (this ensures that incompleted swaps also decrement the required locktime)
+                    self.database.update_backup_tx(&statechain_id, tx.clone())?;
 
                 }
 

--- a/server/src/storage/db.rs
+++ b/server/src/storage/db.rs
@@ -1167,7 +1167,9 @@ impl Database for PGDatabase {
         x1: &FE,
     ) -> Result<()> {
         // Create Transfer table entry
-        self.insert(&statechain_id, Table::Transfer)?;
+        if(!self.transfer_is_completed(statechain_id.clone())) {
+            self.insert(&statechain_id, Table::Transfer)?;
+        }
         self.update(
             statechain_id,
             Table::Transfer,


### PR DESCRIPTION
Transfer sender can be re-run before finalize to enable swaps failure rollback/recovery. Transfer table is updated. 
Backup tx is saved to DB after each signing (prepare_sign) to decrement the locktime correctly. 

New transfer re-send integration test. 