### PR TITLE
Swap timeout

### DIFF
--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -12,6 +12,8 @@ use std::str::FromStr;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ConductorConfig {
+    //Time in seconds that a swap must be completed by once the group has been formed
+    pub group_timeout: u32,
     //Time in seconds that a UTXO registered for a swap must be polled for 
     //in order to remain in a swap group
     pub utxo_timeout: u32, 
@@ -22,6 +24,7 @@ pub struct ConductorConfig {
 impl Default for ConductorConfig {
     fn default() -> Self {
         Self {
+            group_timeout: 600,
             utxo_timeout: 60,
             punishment_duration: 360
         }
@@ -231,6 +234,14 @@ impl Config {
         }
         if let Ok(v) = env::var("MERC_ROCKET_PORT") {
             let _ = conf_rs.set("rocket.port", v)?;
+        }
+
+        if let Ok(v) = env::var("MERC_UTXO_TIMEOUT") {
+            let _ = conf_rs.set("conductor.utxo_timeout", v)?;
+        }
+
+        if let Ok(v) = env::var("MERC_GROUP_TIMEOUT") {
+            let _ = conf_rs.set("conductor.group_timeout", v)?;
         }
 
         // Type checks

--- a/server/src/protocol/conductor.rs
+++ b/server/src/protocol/conductor.rs
@@ -27,7 +27,7 @@ use mockall::predicate::*;
 use mockall::*;
 use rocket::State;
 use rocket_contrib::json::Json;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, LinkedList};
 use std::iter::FromIterator;
 use std::str::FromStr;
 #[cfg(test)]
@@ -39,7 +39,7 @@ use schemars;
 use bitcoin::secp256k1::Signature;
 use chrono::{NaiveDateTime, Utc, Duration};
 
-static DEFAULT_TIMEOUT: u64 = 100;
+static DEFAULT_TIMEOUT: u64 = 600;
 
 #[derive(JsonSchema)]
 #[schemars(remote = "Uuid")]
@@ -149,6 +149,8 @@ pub struct Scheduler {
     time_out_map: BisetMap<Uuid, u64>,
     //A map of state chain id to poll_utxo timeout
     poll_timeout_map: HashMap<Uuid, NaiveDateTime>,
+    //A map of state swap id to swap timeout
+    swap_timeout_map: HashMap<Uuid, NaiveDateTime>,
     //map of swap_id to output addresses and claimed_nonces
     out_addr_map: HashMap<Uuid, BisetMap<SCEAddress, Option<Uuid>>>,
     //map of swap_id to map of state chain id to bst_e_prime values
@@ -171,6 +173,7 @@ impl Scheduler {
             status_map: BisetMap::<Uuid, SwapStatus>::new(),
             time_out_map: BisetMap::<Uuid, u64>::new(),
             poll_timeout_map: HashMap::<Uuid, NaiveDateTime>::new(),
+            swap_timeout_map: HashMap::<Uuid, NaiveDateTime>::new(),
             out_addr_map: HashMap::new(),
             bst_e_prime_map: HashMap::new(),
             bst_sig_map: HashMap::new(),
@@ -182,18 +185,17 @@ impl Scheduler {
         self.swap_id_map.get(statechain_id).cloned()
     }
 
-
     pub fn reset_poll_utxo_timeout(&mut self, statechain_id: &Uuid) -> bool{
         let now: NaiveDateTime = Utc::now().naive_utc();
         let t = now + Duration::seconds(self.utxo_timeout as i64);
         match self.poll_timeout_map.insert(*statechain_id, t){
             Some(t_prev) => {
                 if t_prev <= now {
-                    self.poll_timeout_map.remove(statechain_id);
-                    false
-                } else {
-                    true
-                }
+                        self.poll_timeout_map.remove(statechain_id);
+                        false
+                    } else {
+                        true
+                    }
             },
             None => true
         }
@@ -202,6 +204,39 @@ impl Scheduler {
     pub fn get_poll_utxo_timeout(&self, statechain_id: &Uuid) -> Option<bool> {
         let now: NaiveDateTime = Utc::now().naive_utc();
         match self.poll_timeout_map.get(statechain_id){
+            Some(t) => {
+                Some(&now < t)
+            },
+            None => None
+        }
+    }
+
+    pub fn reset_swap_timeout(&mut self, swap_id: &Uuid, init: bool) -> bool{
+        let now: NaiveDateTime = Utc::now().naive_utc();
+        let t = now + Duration::seconds(DEFAULT_TIMEOUT as i64);
+        match self.swap_timeout_map.insert(*swap_id, t){
+            Some(t_prev) => {
+                if t_prev <= now {
+                        self.swap_timeout_map.remove(swap_id);
+                        false
+                    } else {
+                        true
+                    }
+            },
+            None => {
+                if init {
+                    true
+                } else {
+                    self.swap_timeout_map.remove(swap_id);
+                    false
+                }
+            },
+        }
+    }
+
+    pub fn get_swap_timeout(swap_timeout_map: &HashMap<Uuid, NaiveDateTime>, swap_id: &Uuid) -> Option<bool> {
+        let now: NaiveDateTime = Utc::now().naive_utc();
+        match swap_timeout_map.get(swap_id){
             Some(t) => {
                 Some(&now < t)
             },
@@ -281,6 +316,7 @@ impl Scheduler {
                     .insert(swap_id.to_owned(), i.swap_token.time_out);
                 self.bst_e_prime_map.remove(swap_id);
                 self.bst_sig_map.remove(swap_id);
+                self.swap_timeout_map.remove(swap_id);
                 Some(i)
             }
             None => None,
@@ -385,6 +421,8 @@ impl Scheduler {
                         swap_token,
                         bst_sender_data: BSTSenderData::setup(),
                     };
+                    //Initialize the swap timeout
+                    self.reset_swap_timeout(&swap_id, true);
                     //Add the swap info to the map of swap infos
                     self.insert_swap_info(&si);
                     //Remove the ids from the request lists
@@ -414,53 +452,81 @@ impl Scheduler {
         }
     }
 
+    /*
+    pub fn update_swap_timeouts(&mut self) -> Result<()> {
+        let remove_list: LinkedList<Uuid> = LinkedList::new();
+        for (swap_id, swap_info) in self.swap_info_map.iter_mut() {
+            match self.get_swap_timeout(&swap_info.swap_token.id) {
+                Some(true) => (),
+                _ => {
+                    remove_list.push_back(swap_info.swap_token.id);
+                    continue;
+                }
+        };
+    }
+*/
+
     //Update the swap info based on the results of user first/second messages
     pub fn update_swaps(&mut self) -> Result<()> {
+        let mut remove_list: LinkedList<Uuid> = LinkedList::new();
         for (swap_id, swap_info) in self.swap_info_map.iter_mut() {
-            match swap_info.status {
-                //Phase 1 - check if all state chain addresses have been received, if so:
-                //    - Generate a Blind Spend Tokens for each participant
-                //    - Move swap to phase 2
-                SwapStatus::Phase1 => {
-                    let out_addr_map: &BisetMap<SCEAddress, Option<Uuid>> =
-                        match self.out_addr_map.get(&swap_id) {
-                            Some(out_addr_map) => out_addr_map,
-                            None => return Ok(()), // BisetMap not yet created means no participants have completed swap_msg_1 yet
-                        };
-                    if (swap_info.swap_token.statechain_ids.len() == out_addr_map.len()) {
-                        //All output addresses received.
-                        //Generate a list of blinded spend tokens and proceed to phase 2.
-                        let swap_id = swap_info.swap_token.id;
-                        let scid_bst_map = generate_blind_spend_signatures(
-                            &swap_info,
-                            self.bst_e_prime_map.get(&swap_id),
-                        )?;
-                        self.bst_sig_map.insert(swap_id, scid_bst_map);
-                        swap_info.status = SwapStatus::Phase2;
-                        info!("SCHEDULER: Swap ID: {} moved on to Phase2", swap_id);
+                match Self::get_swap_timeout(&self.swap_timeout_map, &swap_info.swap_token.id) {
+                    Some(true) => (),
+                    _ => {
+                        remove_list.push_back(swap_info.swap_token.id);
+                        continue;
                     }
-                }
-                SwapStatus::Phase2 => {
-                    //Phase 2 - Return BST and SCEAddresses for corresponding valid signtures
-                    //Signature ok. Add the SCEAddress to the list.
-                    let sce_addr_list = match self.out_addr_map.get(swap_id) {
-                        Some(sce_addr_list) => sce_addr_list,
-                        None => {
-                            return Err(SEError::SwapError(
-                                "In phase 2 but no SCEAddress<->claimed_nonce map found"
-                                    .to_string(),
-                            ))
+                };
+
+                match swap_info.status {
+                        //Phase 1 - check if all state chain addresses have been received, if so:
+                        //    - Generate a Blind Spend Tokens for each participant
+                        //    - Move swap to phase 2
+                        SwapStatus::Phase1 => {
+                            let out_addr_map: &BisetMap<SCEAddress, Option<Uuid>> =
+                                match self.out_addr_map.get(&swap_id) {
+                                    Some(out_addr_map) => out_addr_map,
+                                    None => return Ok(()), // BisetMap not yet created means no participants have completed swap_msg_1 yet
+                                };
+                            if (swap_info.swap_token.statechain_ids.len() == out_addr_map.len()) {
+                                //All output addresses received.
+                                //Generate a list of blinded spend tokens and proceed to phase 2.
+                                let swap_id = swap_info.swap_token.id;
+                                let scid_bst_map = generate_blind_spend_signatures(
+                                    &swap_info,
+                                    self.bst_e_prime_map.get(&swap_id),
+                                )?;
+                                self.bst_sig_map.insert(swap_id, scid_bst_map);
+                                swap_info.status = SwapStatus::Phase2;
+                                info!("SCHEDULER: Swap ID: {} moved on to Phase2", swap_id);
+                            }
                         }
-                    };
-                    // Check if there are any unclaimed SCEAddresses
-                    if sce_addr_list.rev_get(&None).len() == 0 {
-                        swap_info.status = SwapStatus::Phase3;
-                    }
-                    info!("SCHEDULER: Swap ID: {} moved on to Phase3", swap_id);
-                }
-                _ => {}
-            };
+                        SwapStatus::Phase2 => {
+                            //Phase 2 - Return BST and SCEAddresses for corresponding valid signtures
+                            //Signature ok. Add the SCEAddress to the list.
+                            let sce_addr_list = match self.out_addr_map.get(swap_id) {
+                                Some(sce_addr_list) => sce_addr_list,
+                                None => {
+                                    return Err(SEError::SwapError(
+                                        "In phase 2 but no SCEAddress<->claimed_nonce map found"
+                                            .to_string(),
+                                    ))
+                                }
+                            };
+                            // Check if there are any unclaimed SCEAddresses
+                            if sce_addr_list.rev_get(&None).len() == 0 {
+                                swap_info.status = SwapStatus::Phase3;
+                            }
+                            info!("SCHEDULER: Swap ID: {} moved on to Phase3", swap_id);
+                        }
+                        _ => {}
+                };
+        };
+
+        for swap_id in remove_list.iter(){
+            self.remove_swap_info(swap_id);
         }
+        
         Ok(())
     }
 
@@ -595,6 +661,10 @@ impl Conductor for SCE {
     fn poll_swap(&self, swap_id: &Uuid) -> Result<Option<SwapStatus>> {
         let mut guard = self.scheduler.lock()?;
         let status = guard.get_swap_status(swap_id);
+        match guard.reset_swap_timeout(swap_id, false){
+            true => (),
+            false => return Err(SEError::SwapError(format!("swap timed out: {}", swap_id))),
+        };
         // If in the batch transfer phase, poll the status of the transfer
         match status {
             Some(v) => match v {
@@ -1092,6 +1162,7 @@ mod tests {
         let statechain_swap_size_map = BisetMap::new();
         let statechain_amount_map = BisetMap::new();
         let mut poll_timeout_map = HashMap::<Uuid, NaiveDateTime>::new();
+        let mut swap_timeout_map = HashMap::<Uuid, NaiveDateTime>::new();
 
         for (swap_size, amount) in swap_size_amounts {
             let id = Uuid::new_v4();
@@ -1110,6 +1181,7 @@ mod tests {
             status_map: BisetMap::<Uuid, SwapStatus>::new(),
             time_out_map: BisetMap::<Uuid, u64>::new(),
             poll_timeout_map,
+            swap_timeout_map,
             out_addr_map: HashMap::new(),
             bst_e_prime_map: HashMap::new(),
             bst_sig_map: HashMap::new(),


### PR DESCRIPTION
Set the swap group timeout in seconds with config variable "group_timeout". After this amount of time after a swap group has been formed, the ongoing swap information will be removed from the scheduler memory.