### PR TITLE
Swap group countdown

### DIFF
--- a/server/Settings.toml
+++ b/server/Settings.toml
@@ -1,19 +1,19 @@
 electrum_server = "127.0.0.1:60401"
-network = "regtest"
+network = "testnet"
 required_confirmation = 0
-testing_mode = false
-lockheight_init = 10000
+testing_mode = true
+lockheight_init = 1000
 lh_decrement = 10
 
 # Fees
-fee_address = "bcrt1qjuwxs60ej7dp4sq9pswhqp7nwmcsng4p8x44mz,bcrt1qjuwxs60ej7dp4sq9pswhqp7nwmcsng4p8x44mz"
+fee_address = "tb1qzvv6yfeg0navfkrxpqc0fjdsu9ey4qgqqsarq4,tb1qzvv6yfeg0navfkrxpqc0fjdsu9ey4qgqqsarq4"
 fee_deposit = 0
 fee_withdraw = 300
 
 # Swap parameters
-punishment_duration = "300" # 1 hour
+punishment_duration = "3600" # 1 hour
 utxo_timeout = "60"
-batch_lifetime = "600" # 1 hour
+batch_lifetime = "3600" # 1 hour
 
 #Mainstay config
 mainstay_config = ""

--- a/server/Settings.toml
+++ b/server/Settings.toml
@@ -1,19 +1,19 @@
 electrum_server = "127.0.0.1:60401"
-network = "testnet"
+network = "regtest"
 required_confirmation = 0
-testing_mode = true
-lockheight_init = 1000
+testing_mode = false
+lockheight_init = 10000
 lh_decrement = 10
 
 # Fees
-fee_address = "tb1qzvv6yfeg0navfkrxpqc0fjdsu9ey4qgqqsarq4,tb1qzvv6yfeg0navfkrxpqc0fjdsu9ey4qgqqsarq4"
+fee_address = "bcrt1qjuwxs60ej7dp4sq9pswhqp7nwmcsng4p8x44mz,bcrt1qjuwxs60ej7dp4sq9pswhqp7nwmcsng4p8x44mz"
 fee_deposit = 0
 fee_withdraw = 300
 
 # Swap parameters
-punishment_duration = "3600" # 1 hour
+punishment_duration = "300" # 1 hour
 utxo_timeout = "60"
-batch_lifetime = "3600" # 1 hour
+batch_lifetime = "600" # 1 hour
 
 #Mainstay config
 mainstay_config = ""

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -31,6 +31,8 @@ pub struct ConductorConfig {
     pub utxo_timeout: u32, 
     /// Length of punishment for unresponsivve/misbehaving batch-transfer utxo
     pub punishment_duration: u64,
+    /// The time waited after a group is started until the swap begins
+    pub init_timeout: u32, 
 }
 
 impl Default for ConductorConfig {
@@ -38,7 +40,8 @@ impl Default for ConductorConfig {
         Self {
             group_timeout: 600,
             utxo_timeout: 60,
-            punishment_duration: 360
+            punishment_duration: 300,
+            init_timeout: 120,
         }
     }
 }

--- a/server/src/protocol/conductor.rs
+++ b/server/src/protocol/conductor.rs
@@ -125,7 +125,7 @@ pub trait Conductor {
     // StateChain they own and should not take any responsibility for the failure.
 
     // Get map of values/sizes to registrations
-    fn get_group_info(&self) -> Result<HashMap<SwapGroup,u64>>;
+    fn get_group_info(&self) -> Result<HashMap<SwapGroup,GroupStatus>>;
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -134,12 +134,14 @@ pub struct Scheduler {
     utxo_timeout: u32,
     //Timeout for swap group to complete
     group_timeout: u32,
+    //Time to initiate swap after group first joined
+    init_timeout: u32,
     //State chain id to requested swap size map
     statechain_swap_size_map: BisetMap<Uuid, u64>,
     //A map of state chain registereds for swap to amount
     statechain_amount_map: BisetMap<Uuid, u64>,
     //A map of swap groups to registrations
-    group_info_map: HashMap<SwapGroup, u64>,
+    group_info_map: HashMap<SwapGroup, GroupStatus>,
     //A map of state chain id to swap id
     swap_id_map: HashMap<Uuid, Uuid>,
     //A map of swap id to swap info
@@ -170,9 +172,10 @@ impl Scheduler {
             group_timeout: config.group_timeout.clone(),
             #[cfg(test)]
             group_timeout: 8,
+            init_timeout: config.init_timeout.clone(),
             statechain_swap_size_map: BisetMap::<Uuid, u64>::new(),
             statechain_amount_map: BisetMap::<Uuid, u64>::new(),
-            group_info_map: HashMap::<SwapGroup, u64>::new(),
+            group_info_map: HashMap::<SwapGroup, GroupStatus>::new(),
             swap_id_map: HashMap::<Uuid, Uuid>::new(),
             swap_info_map: HashMap::<Uuid, SwapInfo>::new(),
             status_map: BisetMap::<Uuid, SwapStatus>::new(),
@@ -271,8 +274,15 @@ impl Scheduler {
                 .insert(statechain_id.to_owned(), swap_size);
 
             let group = SwapGroup { amount: amount, size: swap_size};
-            let count = self.group_info_map.entry(group).or_insert(0);
-            *count += 1;
+            let count = self.group_info_map.entry(group)
+                .or_insert( GroupStatus { number: 0, time: Utc::now().naive_utc() });
+            count.number += 1;
+
+            if (count.number == 2) {
+                count.time = Utc::now().naive_utc() + Duration::seconds(self.init_timeout as i64)
+            }
+
+            println!("group_info_map r {:?}", self.group_info_map);
 
             //metrics
             REG_SWAP_UTXOS.with_label_values(&[&swap_size.clone().to_string(),&amount.clone().to_string()]).inc();
@@ -337,11 +347,14 @@ impl Scheduler {
         let amount = self.statechain_amount_map.get(statechain_id);
         if (self.statechain_amount_map.contains(&statechain_id,&amount[0])) {
             let group = SwapGroup { amount: amount[0], size: swap_size[0]};
-            let count = self.group_info_map.entry(group).or_insert(0);
-            if count > &mut 0 {
-                *count -= 1;
+            let count = self.group_info_map.entry(group)
+                .or_insert( GroupStatus { number: 0, time: Utc::now().naive_utc() } );
+            if count.number > 0 {
+                count.number -= 1;
             }
-            self.group_info_map.retain(|_, &mut v| v != 0);
+            self.group_info_map.retain(|_, v| v.number != 0);
+
+            println!("group_info_map dr {:?}", self.group_info_map);
         }
         self.statechain_amount_map.remove(statechain_id, &amount[0]);
         self.poll_timeout_map.remove(statechain_id);
@@ -385,9 +398,13 @@ impl Scheduler {
             });
             let mut n_remaining = sc_id_vec.len();
 
+            println!("sc_id_vec: {:?}", sc_id_vec);
+
             if n_remaining == 0 {continue};
 
             let swap_size_map = swap_size_map.rev();
+
+            println!("swap_size_map: {:?}", swap_size_map);
 
             //Loop through swap sizes in descending order
             let mut swap_size_collect = swap_size_map.collect();
@@ -400,8 +417,19 @@ impl Scheduler {
                 .to_owned() as usize;
             let mut ids_for_swap = Vec::<Uuid>::new();
             while (!swap_size_collect.is_empty()) {
+
                 //Remove from the back of the vector, which will be the largest swap_size
-                let (swap_size, mut sc_ids) = swap_size_collect.pop().unwrap();
+                let (mut swap_size, mut sc_ids) = swap_size_collect.pop().unwrap();
+
+                let group = SwapGroup { amount: amount.clone(), size: swap_size.clone() };
+                let now: NaiveDateTime = Utc::now().naive_utc();
+                let count = self.group_info_map.entry(group.clone()).or_insert(GroupStatus { number: 0, time: now});
+                // if either group size has been met or that the countdown time has been reached with at least two registrations
+                // if countdown reached with > 1 coin, then use current group size
+                if (sc_ids.len() >= 2 && now >= count.time) {
+                    swap_size = (sc_ids.len() as u64)
+                }
+
                 if (n_remaining + ids_for_swap.len() >= swap_size as usize) {
                     //Collect some ids together for a swap
                     while (!sc_ids.is_empty() && ids_for_swap.len() < swap_size_max) {
@@ -409,9 +437,11 @@ impl Scheduler {
                         ids_for_swap.push(id);
                         n_remaining = n_remaining - 1;
                     }
-                } else {
+                }
+                else {
                     break;
                 }
+
                 //Create a swap token with these ids and clear temporary vector of sc ids
                 if (ids_for_swap.len() == swap_size_max || n_remaining == 0) {
                     let swap_id = Uuid::new_v4();
@@ -439,14 +469,10 @@ impl Scheduler {
                         //as a coherence check
                         assert!(self.statechain_swap_size_map.delete(&id).len() == 1);
                         assert!(self.statechain_amount_map.delete(&id).len() == 1);
-
-                        let group = SwapGroup { amount: amount, size: swap_size};
-                        let count = self.group_info_map.entry(group).or_insert(0);
-                        if count > &mut 0 {
-                            *count -= 1;
-                        }
-                        self.group_info_map.retain(|_, &mut v| v != 0);
                     }
+
+                    self.group_info_map.remove(&group);
+
                     info!("SCHEDULER: Created Swap ID: {}", swap_id);
                     debug!("SCHEDULER: Swap Info: {:?}", si);
                 }
@@ -745,7 +771,7 @@ impl Conductor for SCE {
         Ok(())
     }
 
-    fn get_group_info(&self) -> Result<HashMap<SwapGroup,u64>> {
+    fn get_group_info(&self) -> Result<HashMap<SwapGroup,GroupStatus>> {
         let guard = self.scheduler.as_ref().expect("scheduler is None").lock()?;
         Ok(guard.group_info_map.clone())
     }
@@ -1083,7 +1109,7 @@ pub fn swap_second_message(
 #[get("/swap/groupinfo", format = "json")]
 pub fn get_group_info(
     sc_entity: State<SCE>,
-    ) -> Result<Json<(HashMap<SwapGroup,u64>)>> {
+    ) -> Result<Json<(HashMap<SwapGroup,GroupStatus>)>> {
     match sc_entity.get_group_info() {
         Ok(res) => return Ok(Json(res)),
         Err(e) => return Err(e),
@@ -1185,7 +1211,7 @@ mod tests {
             group_timeout,
             statechain_swap_size_map,
             statechain_amount_map,
-            group_info_map: HashMap::<SwapGroup,u64>::new(),
+            group_info_map: HashMap::<SwapGroup,GroupStatus>::new(),
             swap_id_map: HashMap::<Uuid, Uuid>::new(),
             swap_info_map: HashMap::<Uuid, SwapInfo>::new(),
             status_map: BisetMap::<Uuid, SwapStatus>::new(),

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -449,7 +449,7 @@ mock! {
         fn deregister_utxo(&self, statechain_id: &Uuid) -> conductor::Result<()>;
         fn swap_first_message(&self, swap_msg1: &SwapMsg1) -> conductor::Result<()>;
         fn swap_second_message(&self, swap_msg2: &SwapMsg2) -> conductor::Result<SCEAddress>;
-        fn get_group_info(&self) -> conductor::Result<HashMap<SwapGroup,u64>>;
+        fn get_group_info(&self) -> conductor::Result<HashMap<SwapGroup,GroupStatus>>;
         fn get_blinded_spend_signature(&self, swap_id: &Uuid, statechain_id: &Uuid) -> conductor::Result<BlindedSpendSignature>;
         fn get_address_from_blinded_spend_token(&self, bst: &BlindedSpendToken) -> conductor::Result<SCEAddress>;
     }

--- a/shared/src/structs.rs
+++ b/shared/src/structs.rs
@@ -17,6 +17,7 @@ use schemars;
 use serde::{Serialize, Serializer, Deserialize, Deserializer};
 use serde::de::{self, Visitor, Unexpected};
 use regex::Regex;
+use chrono::{NaiveDateTime, Utc};
 
 use crate::ecies;
 use crate::{util::transaction_serialise, ecies::{Encryptable, SelfEncryptable, WalletDecryptable}};
@@ -128,7 +129,7 @@ impl fmt::Display for StateEntityFeeInfoAPI {
     }
 }
 
-/// Swap group status data
+/// Swap group data
 #[derive(JsonSchema, Debug, Hash, Eq, PartialEq, Clone)]
 #[schemars(example = "Self::example")]
 pub struct SwapGroup {
@@ -193,6 +194,74 @@ impl<'de> Deserialize<'de> for SwapGroup {
         D: Deserializer<'de>,
     {
     deserializer.deserialize_string(SwapGroupVisitor)
+    }
+}
+
+/// Swap group status data
+#[derive(JsonSchema, Debug, Hash, Eq, PartialEq, Clone)]
+#[schemars(example = "Self::example")]
+pub struct GroupStatus {
+    pub number: u64,
+    pub time: NaiveDateTime,
+}
+
+impl GroupStatus {
+    pub fn new(number: u64, time: NaiveDateTime) -> GroupStatus {
+        GroupStatus {number, time}
+    }
+
+    pub fn example() -> Self{
+        Self{
+            number: 2,
+            time: Utc::now().naive_utc(),
+        }
+    }
+}
+
+impl Serialize for GroupStatus {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+   {
+        serializer.serialize_str(&format!("{}:{}", self.number, self.time.timestamp()))
+    }
+}
+
+struct GroupStatusVisitor;
+
+impl<'de> Visitor<'de> for GroupStatusVisitor {
+    type Value = GroupStatus;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a colon-separated pair of u64 integers")
+    }
+
+    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        if let Some(nums) = Regex::new(r"(\d+):(\d+)").unwrap().captures_iter(s).next() {
+            if let Ok(number) = u64::from_str(&nums[1]) {
+                if let Ok(time) = i64::from_str(&nums[2]) {
+                    Ok(GroupStatus::new(number, NaiveDateTime::from_timestamp(time,0)))
+                } else {
+                    Err(de::Error::invalid_value(Unexpected::Str(s), &self))
+                }
+            } else {
+                Err(de::Error::invalid_value(Unexpected::Str(s), &self))
+            }
+        } else {
+            Err(de::Error::invalid_value(Unexpected::Str(s), &self))
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for GroupStatus {
+    fn deserialize<D>(deserializer: D) -> Result<GroupStatus, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+    deserializer.deserialize_string(GroupStatusVisitor)
     }
 }
 


### PR DESCRIPTION
When a swap group (of any size or amount) reaches 2 registrations, a countdown timer is started ( set to config.init_timeout ). When the timeout is reached, the swap executes irrespective of the total registrations (> 1). 

If the group max number is reached before the countdown expires, then the swap executes immediately as before. 