### PR TITLE
Rate limit deposit_init. Include key in rate limit error.

### DIFF
--- a/server/src/protocol/deposit.rs
+++ b/server/src/protocol/deposit.rs
@@ -51,7 +51,7 @@ pub trait Deposit {
 
 impl Deposit for SCE {
     fn deposit_init(&self, deposit_msg1: DepositMsg1) -> Result<UserID> {
-        
+        self.check_rate("deposit_init")?;
         // if Verification/PoW/authoriation failed {
         //      warn!("Failed authorisation.")
         //      Err(SEError::AuthError)

--- a/server/src/protocol/ecdsa.rs
+++ b/server/src/protocol/ecdsa.rs
@@ -162,6 +162,7 @@ impl Ecdsa for SCE {
     }
 
     fn second_message(&self, key_gen_msg2: KeyGenMsg2) -> Result<KeyGenReply2> {
+        self.check_user_auth(&key_gen_msg2.shared_key_id)?;
         self.check_rate("lockbox")?;
         let kg_party_one_second_msg: party1::KeyGenParty1Message2;
         let db = &self.database;

--- a/server/src/protocol/util.rs
+++ b/server/src/protocol/util.rs
@@ -472,7 +472,8 @@ impl Utilities for SCE {
         // If rate_limiter is 'None' the result is Ok. Otherwise, check the rate for 'key'.
         match &self.rate_limiter {
             Some(r) => {
-                r.check_key(&String::from(key))?;
+                r.check_key(&String::from(key))
+                    .map_err(|e| SEError::RateLimitError(format!("{} for key {}",SEError::from(e), key)))?;
                 Ok(())
             },
             None => Ok(())


### PR DESCRIPTION
* Rate limit for deposit init
* Include the key in the rate limit error message
* check_auth in ecdsa second_message