### PR TITLE
Force non-zero StateChain length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "bisetmap",
  "bitcoin",

--- a/server/src/protocol/conductor.rs
+++ b/server/src/protocol/conductor.rs
@@ -39,7 +39,6 @@ use schemars;
 use bitcoin::secp256k1::Signature;
 use chrono::{NaiveDateTime, Utc, Duration,Timelike};
 use crate::protocol::util::RateLimiter;
-use std::convert::TryInto;
 
 const MIN_AMOUNT: u64 = 100000; // bitcoin tx nlocktime cutoff
 const SECONDS_DAY: u32 = 86400;
@@ -1201,6 +1200,7 @@ mod tests {
     use std::collections::HashSet;
     use std::str::FromStr;
     use std::{thread, time::Duration};
+    use std::convert::TryInto;
 
     #[test]
     fn test_swap_token_sig_verify() {

--- a/server/src/protocol/transfer.rs
+++ b/server/src/protocol/transfer.rs
@@ -506,6 +506,7 @@ mod tests {
     use serde_json;
     use bitcoin::Transaction;
     use crate::shared_lib::util::transaction_serialise;
+    use std::convert::TryInto;
 
     // Data from a run of transfer protocol.
     // static TRANSFER_MSG_1: &str = "{\"shared_key_id\":\"707ea4c9-5ddb-4f08-a240-2b4d80ae630d\",\"statechain_sig\":{\"purpose\":\"TRANSFER\",\"data\":\"0213be735d05adea658d78df4719072a6debf152845044402c5fe09dd41879fa01\",\"sig\":\"3044022028d56cfdb4e02d46b2f8158b0414746ddf42ecaaaa995a3a02df8807c5062c0202207569dc0f49b64ae997b4c902539cddc1f4e4434d6b4b05af38af4b98232ebee8\"}}";
@@ -566,7 +567,7 @@ mod tests {
                 Ok(StateChainOwner {
                     locked_until: Utc::now().naive_utc() + Duration::seconds(5),
                     owner_id: shared_key_id,
-                    chain: serde_json::from_str::<StateChain>(&STATE_CHAIN.to_string()).unwrap(),
+                    chain: serde_json::from_str::<StateChainUnchecked>(&STATE_CHAIN.to_string()).unwrap().try_into().unwrap(),
                 })
             });
         db.expect_get_statechain_owner()
@@ -575,7 +576,7 @@ mod tests {
                 Ok(StateChainOwner {
                     locked_until: Utc::now().naive_utc(),
                     owner_id: shared_key_id,
-                    chain: serde_json::from_str::<StateChain>(&STATE_CHAIN.to_string()).unwrap(),
+                    chain: serde_json::from_str::<StateChainUnchecked>(&STATE_CHAIN.to_string()).unwrap().try_into().unwrap(),
                 })
             });
         db.expect_create_transfer().returning(|_, _, _| Ok(()));
@@ -651,7 +652,7 @@ mod tests {
                 })
             });
         db.expect_get_statechain().returning(move |_| {
-            Ok(serde_json::from_str::<StateChain>(&STATE_CHAIN.to_string()).unwrap())
+            Ok(serde_json::from_str::<StateChainUnchecked>(&STATE_CHAIN.to_string()).unwrap().try_into().unwrap())
         });
         db.expect_get_statechain_owner() //Lockbox update
         .with(predicate::eq(statechain_id))
@@ -659,7 +660,7 @@ mod tests {
             Ok(StateChainOwner {
                 locked_until: Utc::now().naive_utc(),
                 owner_id: shared_key_id,
-                chain: serde_json::from_str::<StateChain>(&STATE_CHAIN.to_string()).unwrap(),
+                chain: serde_json::from_str::<StateChainUnchecked>(&STATE_CHAIN.to_string()).unwrap().try_into().unwrap(),
             })
         });
         db.expect_get_lockbox_index().returning(|_| Ok(None));
@@ -795,7 +796,7 @@ mod tests {
                 })
             });
         db.expect_get_statechain().returning(move |_| {
-            Ok(serde_json::from_str::<StateChain>(&STATE_CHAIN.to_string()).unwrap())
+            Ok(serde_json::from_str::<StateChainUnchecked>(&STATE_CHAIN.to_string()).unwrap().try_into().unwrap())
         });
 
         db.expect_get_statechain_owner() //Lockbox update
@@ -804,7 +805,7 @@ mod tests {
             Ok(StateChainOwner {
                 locked_until: Utc::now().naive_utc(),
                 owner_id: shared_key_id,
-                chain: serde_json::from_str::<StateChain>(&STATE_CHAIN.to_string()).unwrap(),
+                chain: serde_json::from_str::<StateChainUnchecked>(&STATE_CHAIN.to_string()).unwrap().try_into().unwrap(),
             })
         });
         db.expect_get_lockbox_index().returning(|_| Ok(Some(0)));

--- a/server/src/protocol/transfer.rs
+++ b/server/src/protocol/transfer.rs
@@ -307,7 +307,7 @@ impl Transfer for SCE {
         // Update state chain
         let mut state_chain: StateChain = self.database.get_statechain(statechain_id)?;
 
-        state_chain.add(finalized_data.statechain_sig.to_owned())?;
+        state_chain.add(&finalized_data.statechain_sig)?;
 
         let new_user_id = finalized_data.new_shared_key_id;
 
@@ -364,9 +364,7 @@ impl Transfer for SCE {
                 .txid
                 .to_string(),
             &state_chain
-                .chain
-                .last()
-                .ok_or(SEError::Generic(String::from("StateChain empty")))?
+                .get_tip()
                 .data
                 .clone(),
         )?;

--- a/server/src/protocol/transfer_batch.rs
+++ b/server/src/protocol/transfer_batch.rs
@@ -19,7 +19,6 @@ use rocket::State;
 use rocket_contrib::json::Json;
 use std::str::FromStr;
 use uuid::Uuid;
-use std::convert::TryInto;
 
 //Generics cannot be used in Rocket State, therefore we define the concrete
 //type of StateChainEntity here
@@ -256,6 +255,7 @@ mod tests {
     use shared_lib::state_chain::State as SCState;
     use std::collections::{HashMap, HashSet};
     use crate::error::DBErrorType;
+    use std::convert::TryInto;
 
     // Useful data structs for transfer batch protocol.
     /// Batch id and Signatures for statechains to take part in batch-transfer

--- a/server/src/protocol/util.rs
+++ b/server/src/protocol/util.rs
@@ -1386,7 +1386,7 @@ pub mod tests {
         });
         db.expect_get_statechain_amount().returning(move |_| {
             Ok(StateChainAmount {
-                chain: serde_json::from_str::<StateChain>(&STATE_CHAIN.to_string()).unwrap(),
+                chain: serde_json::from_str::<StateChainUnchecked>(&STATE_CHAIN.to_string()).unwrap().try_into().unwrap(),
                 amount: 10000,
             })
         });

--- a/server/src/protocol/util.rs
+++ b/server/src/protocol/util.rs
@@ -1048,17 +1048,14 @@ impl<T: Database + Send + Sync + 'static, D: monotree::Database + Send + Sync + 
 
         let state_chain = self.database.get_statechain_amount(statechain_id)?;
 
-        let state = match state_chain.chain.chain.get(0){
-            Some(s) => s.next_state.clone(),
-            None => return Err(SEError::Generic(format!("statechain with id {} is empty", &statechain_id)))
-        };
+        let state = state_chain.chain.get_first().next_state.clone();
 
         if state.is_some() {
                 if state.unwrap().purpose == String::from("WITHDRAW") {
                     return Ok({StateChainDataAPI {
                         amount: state_chain.amount as u64,
                         utxo: OutPoint::null(),
-                        chain: state_chain.chain.chain,
+                        chain: state_chain.chain.get_chain().clone(),
                         locktime: 0 as u32,
                     }});
                 }
@@ -1069,7 +1066,7 @@ impl<T: Database + Send + Sync + 'static, D: monotree::Database + Send + Sync + 
         return Ok({StateChainDataAPI {
             amount: state_chain.amount as u64,
             utxo: tx_backup.input.get(0).unwrap().previous_output,
-            chain: state_chain.chain.chain,
+            chain: state_chain.chain.get_chain().clone(),
             locktime: tx_backup.lock_time,
         }});
     }
@@ -1078,9 +1075,9 @@ impl<T: Database + Send + Sync + 'static, D: monotree::Database + Send + Sync + 
 
         let state_chain = self.database.get_statechain_amount(statechain_id)?;
 
-        let statecoin = state_chain.chain.get_tip()?;
+        let statecoin = state_chain.chain.get_tip();
 
-        match state_chain.chain.get_first()?.next_state {
+        match &state_chain.chain.get_first().next_state {
             Some(state) => {
                 if state.purpose == String::from("WITHDRAW") {
                     return Ok({StateCoinDataAPI {

--- a/server/src/protocol/withdraw.rs
+++ b/server/src/protocol/withdraw.rs
@@ -232,6 +232,7 @@ mod tests {
     use mockall::predicate;
     use std::str::FromStr;
     use uuid::Uuid;
+    use std::convert::TryInto;
 
     // Data from a run of transfer protocol.
     static WITHDRAW_MSG_1: &str = "{\"shared_key_ids\":[\"ad8cb891-ce91-447d-9192-bd105f3de602\"],\"statechain_sigs\":[{\"purpose\":\"WITHDRAW\",\"data\":\"bcrt1qt3jh638mmuzmh92jz8c4wj392p9gj2erf2zut8\",\"sig\":\"304402201abaa7f64b50e8a75ca840a2be6317b501e3b5b5abd057465c165c9b872799f4022000d8e36734857237cab323c7244dd5249295b51905b43bf4e93396b58317d872\"}]}";
@@ -268,7 +269,7 @@ mod tests {
                 Ok(StateChainOwner {
                     locked_until: Utc::now().naive_utc() + Duration::seconds(5),
                     owner_id: shared_key_id,
-                    chain: serde_json::from_str::<StateChain>(STATE_CHAIN).unwrap(),
+                    chain: serde_json::from_str::<StateChainUnchecked>(STATE_CHAIN).unwrap().try_into().unwrap(),
                 })
             });
         db.expect_get_statechain_owner()
@@ -277,7 +278,7 @@ mod tests {
                 Ok(StateChainOwner {
                     locked_until: Utc::now().naive_utc(),
                     owner_id: shared_key_id,
-                    chain: serde_json::from_str::<StateChain>(STATE_CHAIN).unwrap(),
+                    chain: serde_json::from_str::<StateChainUnchecked>(STATE_CHAIN).unwrap().try_into().unwrap(),
                 })
             });
         db.expect_update_withdraw_sc_sig().returning(|_, _| Ok(()));
@@ -340,7 +341,7 @@ mod tests {
             })
         });
         db.expect_get_statechain()
-            .returning(move |_| Ok(serde_json::from_str::<StateChain>(STATE_CHAIN).unwrap()));
+            .returning(move |_| Ok(serde_json::from_str::<StateChainUnchecked>(STATE_CHAIN).unwrap().try_into().unwrap()));
         db.expect_update_statechain_amount()
             .returning(|_, _, _, _| Ok(()));
         db.expect_remove_statechain_id().returning(|_| Ok(()));

--- a/server/src/protocol/withdraw.rs
+++ b/server/src/protocol/withdraw.rs
@@ -79,8 +79,8 @@ impl Withdraw for SCE {
         };
 
         // Verify StateChainSig
-        let prev_proof_key = sco.chain.get_tip()?.data;
-        statechain_sig.verify(&prev_proof_key)?;
+        let prev_proof_key = &sco.chain.get_tip().data;
+        statechain_sig.verify(prev_proof_key)?;
         Ok(sco)
     }
 
@@ -141,7 +141,7 @@ impl Withdraw for SCE {
             // Get statechain and update with final StateChainSig
             let mut state_chain: StateChain = self.database.get_statechain(wcd.statechain_id)?;
 
-            state_chain.add(wcd.withdraw_sc_sig.to_owned())?;
+            state_chain.add(&wcd.withdraw_sc_sig)?;
 
             self.database
                 .update_statechain_amount(&wcd.statechain_id, state_chain, 0, self.coin_value_info.clone())?;

--- a/server/src/storage/db.rs
+++ b/server/src/storage/db.rs
@@ -1089,6 +1089,7 @@ impl Database for PGDatabase {
             vec![Column::Amount, Column::Chain],
         )?;
         let state_chain: StateChain = Self::deser(state_chain_str)?;
+        state_chain.check_non_zero_length()?;
 
         Ok(StateChainAmount {
             chain: state_chain,
@@ -1130,6 +1131,7 @@ impl Database for PGDatabase {
         amount: &i64,
         coins_histo: Arc<Mutex<CoinValueInfo>>
     ) -> Result<()> {
+        state_chain.check_non_zero_length()?;
         let mut guard = coins_histo.as_ref().lock()?;
         self.insert(statechain_id, Table::StateChain)?;
         self.update(
@@ -1160,6 +1162,7 @@ impl Database for PGDatabase {
             vec![Column::Amount, Column::Chain],
         )?;
         let state_chain: StateChain = Self::deser(state_chain_str)?;
+        state_chain.check_non_zero_length()?;
         Ok(state_chain)
     }
 
@@ -1678,6 +1681,7 @@ impl Database for PGDatabase {
         )?;
 
         let chain: StateChain = Self::deser(state_chain_str)?;
+        chain.check_non_zero_length()?;
         Ok(StateChainOwner {
             locked_until,
             owner_id,

--- a/server/src/storage/db.rs
+++ b/server/src/storage/db.rs
@@ -1088,8 +1088,8 @@ impl Database for PGDatabase {
             Table::StateChain,
             vec![Column::Amount, Column::Chain],
         )?;
-        let state_chain: StateChain = Self::deser(state_chain_str)?;
-        state_chain.check_non_zero_length()?;
+        let state_chain: StateChain = 
+            Self::deser::<StateChainUnchecked>(state_chain_str)?.try_into()?;
 
         Ok(StateChainAmount {
             chain: state_chain,
@@ -1131,7 +1131,6 @@ impl Database for PGDatabase {
         amount: &i64,
         coins_histo: Arc<Mutex<CoinValueInfo>>
     ) -> Result<()> {
-        state_chain.check_non_zero_length()?;
         let mut guard = coins_histo.as_ref().lock()?;
         self.insert(statechain_id, Table::StateChain)?;
         self.update(
@@ -1161,8 +1160,8 @@ impl Database for PGDatabase {
             Table::StateChain,
             vec![Column::Amount, Column::Chain],
         )?;
-        let state_chain: StateChain = Self::deser(state_chain_str)?;
-        state_chain.check_non_zero_length()?;
+        let state_chain: StateChain = 
+            Self::deser::<StateChainUnchecked>(state_chain_str)?.try_into()?;
         Ok(state_chain)
     }
 
@@ -1680,8 +1679,8 @@ impl Database for PGDatabase {
             vec![Column::LockedUntil, Column::OwnerId, Column::Chain],
         )?;
 
-        let chain: StateChain = Self::deser(state_chain_str)?;
-        chain.check_non_zero_length()?;
+        let chain: StateChain = 
+            Self::deser::<StateChainUnchecked>(state_chain_str)?.try_into()?;
         Ok(StateChainOwner {
             locked_until,
             owner_id,

--- a/shared/src/state_chain.rs
+++ b/shared/src/state_chain.rs
@@ -44,7 +44,7 @@ impl TryFrom<&Vec<State>> for StateChain {
     type Error = SharedLibError;
     fn try_from(chain: &Vec<State>) -> Result<Self> {
         if chain.is_empty() {
-            return Err(SharedLibError::FormatError("StateChain must be of finite length".to_string()))
+            return Err(SharedLibError::FormatError("StateChain cannot be of zero length".to_string()))
         }
         Ok(Self{ chain: chain.to_owned() })
     }
@@ -54,7 +54,7 @@ impl TryFrom<Vec<State>> for StateChain {
     type Error = SharedLibError;
     fn try_from(chain: Vec<State>) -> Result<Self> {
         if chain.is_empty() {
-            return Err(SharedLibError::FormatError("StateChain must be of finite length".to_string()))
+            return Err(SharedLibError::FormatError("StateChain cannot be of zero length".to_string()))
         }
         Ok(Self{ chain })
     }
@@ -99,6 +99,12 @@ impl StateChain {
             data: statechain_sig.data.clone(),
             next_state: None,
         }))
+    }
+
+    pub fn check_non_zero_length(&self) -> Result<()> {
+        self.chain.last().map(|_| ()).
+            ok_or(SharedLibError::FormatError(
+                "StateChain cannot be of zero length".to_string()))
     }
 
     pub fn example() -> Self{


### PR DESCRIPTION
Simplify enforcement of non-zero StateChain length in the following way:

- Create a new struct with the same data structure as StateChain called StateChainUnchecked that can deserialise.
- Check StateChain length is non-zero on instantiation or conversion from StateChainUnchecked. 
- Do not enable deserilisation for StateChain. 
- Make the data in StateChain and StateChainUnchecked private.

