### PR TITLE
Deposit tx replica check

### DIFF
--- a/client/Settings.toml
+++ b/client/Settings.toml
@@ -1,5 +1,5 @@
 endpoint = "http://0.0.0.0:8000"
-conductor_endpoint = "http://0.0.0.0:8001"
+conductor_endpoint = "http://0.0.0.0:8000"
 electrum_server = "" # Empty string for Mock Electrum server
 testing_mode = "true" # Use testing wallet
 network = "testnet"

--- a/server/src/protocol/util.rs
+++ b/server/src/protocol/util.rs
@@ -386,6 +386,24 @@ impl Utilities for SCE {
                     self.database.update_backup_tx(&statechain_id, tx.clone())?;
                 }
 
+                // Only in deposit case add backup tx to UserSession
+                if prepare_sign_msg.protocol == Protocol::Deposit {
+                    // check if there is an existing backup transaction (from a previous deposit confirm)
+                    // if there is: verify that the locktime of the new tx is the same and the destination address
+                    let locktime = match self.database.get_user_backup_tx(user_id.clone()) {
+                        Ok(old_tx) => old_tx.lock_time as u32,
+                        Err(_) => 0 as u32
+                    };
+
+                    if ((locktime == 0 as u32) || locktime == tx.lock_time as u32) {
+                        self.database.update_user_backup_tx(&user_id, tx.clone())?;
+                    } else {
+                        return Err(SEError::Generic(String::from(
+                            "Replacement backup tx locktime not correct.",
+                        )));
+                    }
+                }
+
                 let sig_hash = get_sighash(
                     &tx,
                     &0,
@@ -395,12 +413,6 @@ impl Utilities for SCE {
                 );
 
                 self.database.update_sighash(&user_id, sig_hash)?;
-
-                // Only in deposit case add backup tx to UserSession
-                if prepare_sign_msg.protocol == Protocol::Deposit {
-                    self.database
-                        .update_user_backup_tx(&user_id, tx)?;
-                }
 
                 info!(
                     "DEPOSIT: Backup tx ready for signing. Shared Key ID: {}.",


### PR DESCRIPTION
If a new deposit backup tx is signed, the locktime must be the same as previous txs. 