### PR TITLE
Batch id for transfer sender

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3942,7 +3942,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "bisetmap",
  "bitcoin",

--- a/client/src/daemon.rs
+++ b/client/src/daemon.rs
@@ -246,6 +246,7 @@ pub fn run_wallet_daemon(force_testing_mode: bool) -> Result<()> {
                             &mut wallet,
                             &statechain_id,
                             sce_address,
+                            None
                         );
                         let encoded_message = encoding::encode_message(transfer_sender_resp.unwrap());
                         wallet.save();
@@ -264,6 +265,7 @@ pub fn run_wallet_daemon(force_testing_mode: bool) -> Result<()> {
                                 &mut wallet,
                                 &statechain_ids[0],
                                 sce_address,
+                                None
                             );
                             encoded_message = encoding::encode_message(transfer_sender_resp.unwrap()).unwrap();
                             wallet.save();

--- a/client/src/state_entity/conductor.rs
+++ b/client/src/state_entity/conductor.rs
@@ -46,6 +46,7 @@ pub fn swap_register_utxo(wallet: &Wallet, statechain_id: &Uuid, swap_size: &u64
             statechain_id: statechain_id.to_owned(),
             signature: statechain_sig,
             swap_size: swap_size.to_owned(),
+            wallet_version: "0.4.66".to_string(),
         },
     )
 }
@@ -279,7 +280,7 @@ pub fn do_swap(
         thread::sleep(time::Duration::from_secs(3));
     }
 
-    let _ = transfer::transfer_sender(&mut wallet, statechain_id, receiver_addr)?;
+    let _ = transfer::transfer_sender(&mut wallet, statechain_id, receiver_addr, Some(swap_id.clone()) )?;
 
     let mut commitment_data = statechain_id.to_string();
     let mut sorted_sc_ids = info.swap_token.statechain_ids.clone();

--- a/client/src/state_entity/transfer.rs
+++ b/client/src/state_entity/transfer.rs
@@ -38,6 +38,7 @@ pub fn transfer_sender(
     wallet: &mut Wallet,
     statechain_id: &Uuid,
     receiver_addr: SCEAddress,
+    batch_id: Option<Uuid>
 ) -> Result<TransferMsg3> {
     // Get required shared key data
     let shared_key_id;
@@ -77,6 +78,7 @@ pub fn transfer_sender(
         &TransferMsg1 {
             shared_key_id: shared_key_id.to_owned(),
             statechain_sig: statechain_sig.clone(),
+            batch_id: batch_id,
         },
     )?;
 

--- a/integration-tests/src/batch_transfer_test.rs
+++ b/integration-tests/src/batch_transfer_test.rs
@@ -191,6 +191,7 @@ mod tests {
             &mut wallets[0],
             &statechain_ids[0],
             receiver_addr.clone(),
+            Some(batch_id.clone()),
         ) {
             Err(e) => {
                 assert!(e.to_string().contains("State Chain not owned by User ID:"));
@@ -360,6 +361,7 @@ mod tests {
                 &mut wallets[i],
                 &deposits[i].1, // state chain id
                 receiver_addr.clone(),
+                Some(batch_id.clone())
             ) {
                 Err(e) => {
                     assert!(e.to_string().contains("State Chain locked for"));

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -289,6 +289,7 @@ pub fn run_transfer(
         &mut wallets[sender_index],
         statechain_id,
         receiver_addr.clone(),
+        None
     )
     .unwrap();
 
@@ -331,6 +332,7 @@ pub fn run_transfer_with_commitment(
         &mut wallets[sender_index],
         sender_statechain_id,
         receiver_addr.clone(),
+        Some(batch_id.clone())
     )
     .unwrap();
 
@@ -342,6 +344,16 @@ pub fn run_transfer_with_commitment(
     }
 
     let (commitment, nonce) = make_commitment(&commitment_data);
+
+    // check that we cannot run transfer_receiver without batch data
+    match state_entity::transfer::transfer_receiver(
+        &mut wallets[receiver_index],
+        &mut tranfer_sender_resp.clone(),
+        &None
+        ) {
+        Err(e) => assert!(e.to_string().contains("Expect receive in batch ID")),
+        _ => assert!(false),
+    }
 
     let transfer_finalized_data = state_entity::transfer::transfer_receiver(
         &mut wallets[receiver_index],

--- a/integration-tests/src/test.rs
+++ b/integration-tests/src/test.rs
@@ -312,6 +312,7 @@ mod tests {
             &mut wallets[0],
             &statechain_id,
             receiver_addr.clone(),
+            None
         )
         .unwrap();
 
@@ -325,6 +326,7 @@ mod tests {
             &mut wallets[0],
             &statechain_id,
             receiver_addr.clone(),
+            None
         )
         .unwrap();
 
@@ -618,6 +620,7 @@ mod tests {
             &mut wallet,
             statechain_id,
             receiver_addr.clone(),
+            None
         );
         assert!(send_result.is_err() && format!("{:?}",send_result)
         .contains("is signed for withdrawal"));

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -184,6 +184,7 @@ pub trait Database {
         statechain_id: &Uuid,
         statechain_sig: &StateChainSig,
         x1: &FE,
+        batch_id: Option<Uuid>
     ) -> Result<()>;
     fn update_transfer_msg(&self, statechain_id: &Uuid, msg: &TransferMsg3) -> Result<()>;
     fn get_transfer_msg(&self, statechain_id: &Uuid) -> Result<TransferMsg3>;
@@ -324,6 +325,7 @@ pub mod structs {
         pub statechain_id: Uuid,
         pub statechain_sig: StateChainSig,
         pub x1: FE,
+        pub batch_id: Option<Uuid>,
     }
 
     pub struct ECDSAKeypair {

--- a/server/src/storage/db.rs
+++ b/server/src/storage/db.rs
@@ -1312,17 +1312,18 @@ impl Database for PGDatabase {
                 vec![
                     &Self::ser(statechain_sig.to_owned())?,
                     &Self::ser(x1.to_owned())?,
-                    &Self::ser(batch_id.unwrap().to_owned())?,
+                    &batch_id.unwrap().to_owned(),
                 ],
             )
         } else {
             self.update(
                 statechain_id,
                 Table::Transfer,
-                vec![Column::StateChainSig, Column::X1],
+                vec![Column::StateChainSig, Column::X1, Column::BatchId],
                 vec![
                     &Self::ser(statechain_sig.to_owned())?,
                     &Self::ser(x1.to_owned())?,
+                    &None::<Uuid>
                 ],
             )
         }

--- a/server/src/storage/db.rs
+++ b/server/src/storage/db.rs
@@ -130,6 +130,7 @@ pub enum Column {
     StateChainSig,
     X1,
     TransferMsg,
+    BatchId,
 
     // TransferBatch
     // Id,
@@ -332,6 +333,7 @@ impl PGDatabase {
                 x1 varchar,
                 transfermsg varchar,
                 proofkey varchar,
+                batchid uuid,
                 PRIMARY KEY (id)
             );",
                 Table::Transfer.to_string(),
@@ -1296,20 +1298,34 @@ impl Database for PGDatabase {
         statechain_id: &Uuid,
         statechain_sig: &StateChainSig,
         x1: &FE,
+        batch_id: Option<Uuid>
     ) -> Result<()> {
         // Create Transfer table entry
         if(!self.transfer_is_completed(statechain_id.clone())) {
             self.insert(&statechain_id, Table::Transfer)?;
         }
-        self.update(
-            statechain_id,
-            Table::Transfer,
-            vec![Column::StateChainSig, Column::X1],
-            vec![
-                &Self::ser(statechain_sig.to_owned())?,
-                &Self::ser(x1.to_owned())?,
-            ],
-        )
+        if batch_id.is_some() {
+            self.update(
+                statechain_id,
+                Table::Transfer,
+                vec![Column::StateChainSig, Column::X1, Column::BatchId],
+                vec![
+                    &Self::ser(statechain_sig.to_owned())?,
+                    &Self::ser(x1.to_owned())?,
+                    &Self::ser(batch_id.unwrap().to_owned())?,
+                ],
+            )
+        } else {
+            self.update(
+                statechain_id,
+                Table::Transfer,
+                vec![Column::StateChainSig, Column::X1],
+                vec![
+                    &Self::ser(statechain_sig.to_owned())?,
+                    &Self::ser(x1.to_owned())?,
+                ],
+            )
+        }
     }
 
     fn update_transfer_msg(&self, statechain_id: &Uuid, msg: &TransferMsg3) -> Result<()> {
@@ -1372,10 +1388,10 @@ impl Database for PGDatabase {
     }
 
     fn get_transfer_data(&self, statechain_id: Uuid) -> Result<TransferData> {
-        let (statechain_id, statechain_sig_str, x1_str) = self.get_3::<Uuid, String, String>(
+        let (statechain_id, statechain_sig_str, x1_str, batch_id) = self.get_4::<Uuid, String, String, Option<Uuid>>(
             statechain_id,
             Table::Transfer,
-            vec![Column::Id, Column::StateChainSig, Column::X1],
+            vec![Column::Id, Column::StateChainSig, Column::X1, Column::BatchId],
         )?;
 
         let statechain_sig: StateChainSig = Self::deser(statechain_sig_str)?;
@@ -1385,6 +1401,7 @@ impl Database for PGDatabase {
             statechain_id,
             statechain_sig,
             x1,
+            batch_id,
         });
     }
 

--- a/server/src/storage/monotree.rs
+++ b/server/src/storage/monotree.rs
@@ -512,6 +512,7 @@ impl Database for MemoryDB {
         _statechain_id: &uuid::Uuid,
         _statechain_sig: &shared_lib::state_chain::StateChainSig,
         _x1: &curv::FE,
+        _batch_id: Option<uuid::Uuid>
     ) -> crate::Result<()> {
         unimplemented!()
     }

--- a/shared/src/structs.rs
+++ b/shared/src/structs.rs
@@ -696,6 +696,8 @@ pub struct TransferMsg1 {
     #[schemars(with = "UuidDef")]
     pub shared_key_id: Uuid,
     pub statechain_sig: StateChainSig,
+    #[schemars(with = "UuidDef")]
+    pub batch_id: Option<Uuid>,
 }
 
 #[derive(JsonSchema)]


### PR DESCRIPTION
If batch transfer, batch id is supplied to transfer sender and stored in the transfer table. 
On transfer receiver, the batch ID is checked. 