### PR TITLE
Backup tx update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,7 +1042,7 @@ version = "0.2.1"
 source = "git+https://github.com/commerceblock/rs.git?branch=rust-crypto#6b3a4b5b6234e3fc6f8049bec5f407dd62dac8ad"
 dependencies = [
  "hex 0.4.3",
- "libsecp256k1",
+ "libsecp256k1 0.3.5",
  "rand 0.7.3",
  "rust-crypto",
  "sha2 0.9.3",
@@ -1586,6 +1586,16 @@ dependencies = [
 
 [[package]]
 name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
@@ -1603,6 +1613,17 @@ dependencies = [
  "digest 0.8.1",
  "generic-array 0.12.4",
  "hmac 0.7.1",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array 0.14.4",
+ "hmac 0.8.1",
 ]
 
 [[package]]
@@ -1981,11 +2002,59 @@ dependencies = [
  "arrayref",
  "crunchy",
  "digest 0.8.1",
- "hmac-drbg",
+ "hmac-drbg 0.2.0",
  "rand 0.7.3",
  "sha2 0.8.2",
  "subtle 2.4.0",
  "typenum",
+]
+
+[[package]]
+name = "libsecp256k1"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
+dependencies = [
+ "arrayref",
+ "base64 0.12.3",
+ "digest 0.9.0",
+ "hmac-drbg 0.3.0",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.7.3",
+ "serde 1.0.125",
+ "sha2 0.9.3",
+ "typenum",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle 2.4.0",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccab96b584d38fac86a83f07e659f0deafd0253dc096dab5a36d53efe653c5c3"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
+dependencies = [
+ "libsecp256k1-core",
 ]
 
 [[package]]
@@ -3942,7 +4011,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.3.20"
+version = "0.3.22"
 dependencies = [
  "bisetmap",
  "bitcoin",
@@ -4070,7 +4139,7 @@ dependencies = [
  "itertools 0.9.0",
  "jsonrpc",
  "kms",
- "libsecp256k1",
+ "libsecp256k1 0.5.0",
  "log 0.4.14",
  "merkletree",
  "mockito",

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -170,6 +170,8 @@ pub trait Database {
     fn get_current_backup_txs(&self, locktime: i64) -> Result<Vec<BackupTxID>>;
     fn remove_backup_tx(&self, statechain_id: &Uuid) -> Result<()>;
     fn get_backup_transaction(&self, statechain_id: Uuid) -> Result<Transaction>;
+    fn get_backup_locktime(&self, statechain_id: Uuid) -> Result<i64>;
+    fn update_backup_locktime(&self, statechain_id: Uuid, locktime: i64) -> Result<()>;
     fn get_backup_transaction_and_proof_key(&self, user_id: Uuid) -> Result<(Transaction, String)>;
     fn get_proof_key(&self, user_id: Uuid) -> Result<String>;
     fn get_sc_locked_until(&self, statechain_id: Uuid) -> Result<NaiveDateTime>;

--- a/server/src/storage/db.rs
+++ b/server/src/storage/db.rs
@@ -1229,6 +1229,21 @@ impl Database for PGDatabase {
         Ok(tx_backup)
     }
 
+    fn get_backup_locktime(&self, statechain_id: Uuid) -> Result<i64> {
+        let backup_locktime =
+            self.get_1::<i64>(statechain_id, Table::BackupTxs, vec![Column::LockTime])?;
+        Ok(backup_locktime)
+    }
+
+    fn update_backup_locktime(&self,statechain_id: Uuid, locktime: i64) -> Result<()> {
+        self.update(
+            &statechain_id,
+            Table::BackupTxs,
+            vec![Column::LockTime],
+            vec![&(locktime)],
+        )
+    }    
+
     fn get_proof_key(&self, user_id: Uuid) -> Result<String> {
         let proof_key =
             self.get_1::<String>(user_id, Table::UserSession, vec![Column::ProofKey])?;

--- a/server/src/storage/monotree.rs
+++ b/server/src/storage/monotree.rs
@@ -472,6 +472,18 @@ impl Database for MemoryDB {
     fn get_backup_transaction(&self, _statechain_id: uuid::Uuid) -> crate::Result<bitcoin::Transaction> {
         unimplemented!()
     }
+    fn get_backup_locktime(
+        &self, 
+        _statechain_id: uuid::Uuid,
+    ) -> crate::Result<i64> {
+        unimplemented!()        
+    }
+    fn update_backup_locktime(
+        &self, 
+        _statechain_id: uuid::Uuid, 
+        _locktime: i64) -> crate::Result<()> {
+        unimplemented!() 
+    }
     fn get_backup_transaction_and_proof_key(
         &self,
         _user_id: uuid::Uuid,


### PR DESCRIPTION
The backup tx is no longer updated each time `prepare_sign_tx` is called. Now, the locktime column in the table is decremented, but the backup tx itself is only updated on transfer_finalize. 