### PR TITLE
Add rust-toolchain with the expected nightly version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2021-07-16"


### PR DESCRIPTION
Add `rust-toolchain.toml` with the expected nightly version (`nightly-2021-07-16`).
With this file, the project can be built right after cloning, without manually configuring the toolchain.
This also documents the right toolchain version.