### PR TITLE
Fix column name and error propagation

### DIFF
--- a/server/src/protocol/ecdsa.rs
+++ b/server/src/protocol/ecdsa.rs
@@ -198,7 +198,6 @@ impl Ecdsa for SCE {
                     Ok(r) => kg_party_one_second_msg = r,
                     Err(_dberr) => { let path: &str = "ecdsa/keygen/second";
                                     let kg_party_one_second_message: party1::KeyGenParty1Message2 = post_lb(&lockbox_url, path, &key_gen_msg2)?;
-                                    let _ = db.set_keygen_second_msg(&user_id, &kg_party_one_second_message);
                                     kg_party_one_second_msg = kg_party_one_second_message;
                     }
                 }
@@ -229,6 +228,8 @@ impl Ecdsa for SCE {
                 kg_party_one_second_msg = kg_party_one_second_message;
             }
         }
+
+        db.set_keygen_second_msg(&user_id, &kg_party_one_second_msg)?;
 
         db.update_s1_pubkey(&key_gen_msg2.shared_key_id, 
             &kg_party_one_second_msg

--- a/server/src/storage/db.rs
+++ b/server/src/storage/db.rs
@@ -297,7 +297,7 @@ impl PGDatabase {
                 epheckeypair varchar,
                 ephkeygenfirstmsg varchar,
                 complete bool NOT NULL DEFAULT false,
-                keygensecondmessage varchar,
+                keygensecondmsg varchar,
                 PRIMARY KEY (id)
             );",
                 Table::Ecdsa.to_string(),


### PR DESCRIPTION
The column in table ECDSA is created with the name `keygensecondmessage` while the enum has the name `KeyGenSecondMsg`.
This causes an error because the column does not exist.

Also, the `db.set_keygen_second_msg` command is not propagating the error, so `?` has been added.

And it has been moved to the end of the function, so the same command can be used both for lockbox and server.