### PR TITLE
Fix client error not recognizing own SE address

### DIFF
--- a/client/src/state_entity/transfer.rs
+++ b/client/src/state_entity/transfer.rs
@@ -317,8 +317,8 @@ pub fn transfer_receiver_repeat_keygen(
         "Failed to decode ScriptpubKey.",
     )))?;
     wallet
-        .se_backup_keys
-        .get_address_derivation(&back_up_rec_se_addr.to_string())
+        .se_proof_keys
+        .get_key_derivation_address(&back_up_rec_se_addr.to_string())
         .ok_or(CError::Generic(String::from(
             "Backup Tx receiving address not found in this wallet!",
         )))?;


### PR DESCRIPTION
SE addresses are generated in the `get_new_state_entity_address` function, which gets a new key from `se_proof_keys`.

This new address is added to `se_backup_keys` via the `add_address` function. This function adds the new key in `addresses_derivation_map`, but apparently the manually added items in this one don't persist.

When the wallet is loaded, the keys of `se_backup_keys` are fully derivation generated and there is no way to get the keys added manually.

This way, if the client generates an SE address and then restarts, it can no longer receive through that address.

This PR suggests a workaround for this problem. Instead of looking in `se_backup_keys`, it looks for the key directly in `se_proof_keys`, which is the derivation in which the key was generated.