### PR TITLE
Change swap to use `get_new_state_entity_address` function

### DIFF
--- a/client/src/state_entity/conductor.rs
+++ b/client/src/state_entity/conductor.rs
@@ -223,14 +223,7 @@ pub fn do_swap(
         thread::sleep(time::Duration::from_secs(3));
     }
 
-    let proof_key = wallet.se_proof_keys.get_new_key()?;
-
-    let proof_key = bitcoin::secp256k1::PublicKey::from_slice(&proof_key.to_bytes().as_slice())?;
-
-    let address = SCEAddress {
-        tx_backup_addr: None,
-        proof_key,
-    };
+    let address = wallet.get_new_state_entity_address()?;
 
     let transfer_batch_sig = transfer::transfer_batch_sign(wallet, &statechain_id, &swap_id)?;
 


### PR DESCRIPTION
Currently the `do_swap` function manually generates the SE address for the swap but does not add it to `se_backup_keys` nor assign a `tx_backup_addr` to it.

Apparently there is no need to re-implement the SE address generation logic as there is a `get_new_state_entity_address` function that already does that.

This PR aims to fix the bug `thread 'tokio-runtime-worker-0' panicked at 'called `Result::unwrap()` on an `Err` value: Generic("Backup Tx receiving address not found in this wallet!")', client/src/daemon.rs:302:26` which happens in swap process, but the error persists even after this patch.

Even so, for the reasons mentioned above, I still think it's worth the fix proposed by PR or at least a discussion about how the SE address is being generated in the swap process.