### PR TITLE
Remove `se_backup_keys` from client

### DIFF
--- a/client/src/state_entity/deposit.rs
+++ b/client/src/state_entity/deposit.rs
@@ -126,7 +126,10 @@ pub fn deposit(
     debug!("Deposit: Set initial locktime: {}", init_locktime.to_string());
 
     // Make unsigned backup tx
-    let backup_receive_addr = wallet.se_backup_keys.get_new_address()?;
+    let backup_receive_addr = bitcoin::Address::p2wpkh(
+        &proof_key,
+        wallet.get_bitcoin_network(),
+    )?;
     
     let tx_backup_unsigned =
         tx_backup_build(&tx_funding_signed.txid(), &backup_receive_addr, &amount, &init_locktime, &withdraw_fee, &se_fee_info.address, &se_fee_info.backup_fee_rate)?;

--- a/client/src/state_entity/transfer.rs
+++ b/client/src/state_entity/transfer.rs
@@ -317,8 +317,8 @@ pub fn transfer_receiver_repeat_keygen(
         "Failed to decode ScriptpubKey.",
     )))?;
     wallet
-        .se_backup_keys
-        .get_address_derivation(&back_up_rec_se_addr.to_string())
+        .se_proof_keys
+        .get_key_derivation_address(&back_up_rec_se_addr.to_string())
         .ok_or(CError::Generic(String::from(
             "Backup Tx receiving address not found in this wallet!",
         )))?;


### PR DESCRIPTION
This PR removes `se_backup_keys` from the client.
Deposit, withdrawal and transfer operations successfully tested.
The swap operation continues with the same issue as on the master branch.
`cargo test` was executed successfully.