### PR TITLE
Instead of using `tx_backup_addr`, use `proof_key` to set the new owner

### DIFF
--- a/client/src/state_entity/transfer.rs
+++ b/client/src/state_entity/transfer.rs
@@ -192,13 +192,15 @@ pub fn transfer_sender(
 
     let mut tx = transaction_deserialise(&prepare_sign_msg.tx_hex)?;
 
+    let backup_receive_addr = bitcoin::Address::p2wpkh(
+        &PublicKey::from_slice(&receiver_addr.proof_key.serialize()).unwrap(),
+        wallet.get_bitcoin_network(),
+    )?;
+
     // Update prepare_sign_msg with new owners address, proof key
     prepare_sign_msg.protocol = Protocol::Transfer;
     match tx.output.get_mut(0) {
-        Some(v) => match receiver_addr.tx_backup_addr.clone() {
-            Some(v2) => v.script_pubkey = v2.script_pubkey(),
-            None => (),
-        },
+        Some(v) => v.script_pubkey = backup_receive_addr.script_pubkey(),
         None => (),
     };
     prepare_sign_msg.proof_key = Some(receiver_addr.proof_key.clone().to_string());


### PR DESCRIPTION
The `swap/second` returns a SCEAddress with null `tx_backup_addr` and `transfer_sender` function uses this to replace the previous owner. 

If the `tx_backup_addr` is null, the previous owner persists and then the error `Backup Tx Receiving Address not found in this wallet` occurs in the swap process.

Using `proof_key` to set the new owner in the backup transaction fixes this.