### PR TITLE
Increase request timeout

### DIFF
--- a/client/src/utilities/requests.rs
+++ b/client/src/utilities/requests.rs
@@ -4,6 +4,7 @@
 
 use floating_duration::TimeFormat;
 use serde;
+use std::time::Duration;
 use std::time::Instant;
 
 use super::super::ClientShim;
@@ -33,6 +34,8 @@ where
     if client_shim.auth_token.is_some() {
         b = b.bearer_auth(client_shim.auth_token.clone().unwrap());
     }
+
+    b = b.timeout(Duration::from_secs(300));
 
     // catch reqwest errors
     let value = match b.json(&body).send() {
@@ -81,6 +84,8 @@ where
     if client_shim.auth_token.is_some() {
         b = b.bearer_auth(client_shim.auth_token.clone().unwrap());
     }
+
+    b = b.timeout(Duration::from_secs(300));
 
     // catch reqwest errors
     let value = match b.send() {


### PR DESCRIPTION
This PR increases the GET/POST request timeout so that the client can complete the swap operation.

The JS wallet also seems to use a high timeout.
https://github.com/layer2tech/mercury-wallet/blob/d96df82c51223466260407c22865452867267f7a/src/wallet/http_client.ts#L7